### PR TITLE
fix getByKey with expand when resource not found

### DIFF
--- a/src/services/product-projection.test.ts
+++ b/src/services/product-projection.test.ts
@@ -56,6 +56,17 @@ describe('Product Projection', () => {
     })
   })
 
+  test('Get product projection by 404 when not found by key with expand', async () => {
+    const response = await supertest(ctMock.app).get(
+      '/dummy/product-projections/key=DOESNOTEXIST?' +
+        qs.stringify({
+          expand: ['categories[*]'],
+        })
+    )
+
+    expect(response.status).toBe(404)
+  })
+
   test('Search product projection', async () => {
     ctMock.project('dummy').add('product-projection', {
       id: '',

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -211,8 +211,14 @@ export class InMemoryStorage extends AbstractStorage {
 
     const resources: any[] = Array.from(store.values())
     const resource = resources.find(e => e.key === key)
-    if (params.expand) return this.expand(projectKey, resource, params.expand)
-    return resource
+    if (resource) {
+      return this.expand(
+        projectKey,
+        resource,
+        params.expand
+      ) as ResourceMap[RepositoryTypes]
+    }
+    return null
   }
 
   delete(


### PR DESCRIPTION
When requesting a resource which doesn't exists via withKey, and the expand query string, an error was raised.

For example:
`/us-unittest/product-projections/key=invalid?expand=categories%5B*%5D`

This PR implements a fix for this, that expand is only executed when resource is found.