### PR TITLE
Add support for offset and limit query string

### DIFF
--- a/src/repositories/abstract.ts
+++ b/src/repositories/abstract.ts
@@ -14,6 +14,8 @@ import { CommercetoolsError } from '../exceptions'
 export type QueryParams = {
   expand?: string[]
   where?: string[]
+  offset?: number
+  limit?: number
 }
 
 export type GetParams = {
@@ -69,6 +71,8 @@ export abstract class AbstractResourceRepository extends AbstractRepository {
     return this._storage.query(projectKey, this.getTypeId(), {
       expand: params.expand,
       where: params.where,
+      offset: params.offset,
+      limit: params.limit,
     })
   }
 

--- a/src/repositories/product-projection.ts
+++ b/src/repositories/product-projection.ts
@@ -55,6 +55,8 @@ export class ProductProjectionRepository extends AbstractResourceRepository {
 
     const results = this._storage.query(projectKey, this.getTypeId(), {
       where: wherePredicate,
+      offset: query.offset ? Number(query.offset) : undefined,
+      limit: query.limit ? Number(query.limit) : undefined,
     }) //TODO: this is a partial implementation, but I don't really have the time to implement an actual search API right now
 
     return results

--- a/src/services/abstract.ts
+++ b/src/services/abstract.ts
@@ -37,11 +37,14 @@ export default abstract class AbstractService {
   }
 
   get(request: Request, response: Response) {
+    const limit = this._parseParam(request.query.limit)
+    const offset = this._parseParam(request.query.offset)
+
     const result = this.repository.query(request.params.projectKey, {
       expand: this._parseParam(request.query.expand),
       where: this._parseParam(request.query.where),
-      limit: this._parseParam(request.query.limit),
-      offset: this._parseParam(request.query.offset),
+      limit: limit !== undefined ? Number(limit) : undefined,
+      offset: offset !== undefined ? Number(offset) : undefined,
     })
     return response.status(200).send(result)
   }

--- a/src/services/abstract.ts
+++ b/src/services/abstract.ts
@@ -40,6 +40,8 @@ export default abstract class AbstractService {
     const result = this.repository.query(request.params.projectKey, {
       expand: this._parseParam(request.query.expand),
       where: this._parseParam(request.query.where),
+      limit: this._parseParam(request.query.limit),
+      offset: this._parseParam(request.query.offset),
     })
     return response.status(200).send(result)
   }

--- a/src/services/product-projection.test.ts
+++ b/src/services/product-projection.test.ts
@@ -118,6 +118,26 @@ describe('Product Projection Search', () => {
     })
   })
 
+  test('Search product projection page 2', async () => {
+    const response = await supertest(ctMock.app).get(
+      '/dummy/product-projections/search?' +
+        qs.stringify({
+          filter: ['masterVariant.sku:"1337"'],
+          limit: 50,
+          offset: 100
+        })
+    )
+
+    const projection: ProductProjection = response.body
+    expect(projection).toEqual({
+      count: 1,
+      limit: 50,
+      offset: 100,
+      total: 0,
+      results: [],
+    })
+  })
+
   test('Search product projection with query.filter', async () => {
     const response = await supertest(ctMock.app).get(
       '/dummy/product-projections/search?' +

--- a/src/services/product-projection.test.ts
+++ b/src/services/product-projection.test.ts
@@ -124,7 +124,7 @@ describe('Product Projection Search', () => {
         qs.stringify({
           filter: ['masterVariant.sku:"1337"'],
           limit: 50,
-          offset: 100
+          offset: 100,
         })
     )
 


### PR DESCRIPTION
This PR adds support for offset and limit query strings.

For example, if you request `/product-projects/?offset=10&limit=10`, the response will also return `{offset: 10, limit: 10}`.