### PR TITLE
fixed bug introduced with product identifiers

### DIFF
--- a/src/repositories/cart.ts
+++ b/src/repositories/cart.ts
@@ -305,10 +305,8 @@ export class CartRepository extends AbstractResourceRepository {
     draftLineItem: LineItemDraft
   ): LineItem => {
     const { productId, quantity } = draftLineItem
-    // @ts-ignore
-    let variantId = draftLineItem.variant.id
-    // @ts-ignore
-    let sku = draftLineItem.variant.sku
+    let variantId = draftLineItem.variantId
+    let sku = draftLineItem.sku
     let product: Product | null = null
     let variant: ProductVariant | undefined
 


### PR DESCRIPTION
Fixed bug with using variant/product identifiers in line item drafts: https://github.com/labd/commercetools-node-mock/pull/32/files

A LineItemDraft never has a `variant` object.