### PR TITLE
Add in-store paths

### DIFF
--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -139,7 +139,11 @@ export class CommercetoolsMock {
     // Only enable auth middleware if we have enabled this
     if (this.options.enableAuthentication) {
       app.use('/:projectKey', this._oauth2.createMiddleware(), projectRouter)
-      app.use('/:projectKey/in-store/key=:storeKey', this._oauth2.createMiddleware(), projectRouter)
+      app.use(
+        '/:projectKey/in-store/key=:storeKey',
+        this._oauth2.createMiddleware(),
+        projectRouter
+      )
     } else {
       app.use('/:projectKey', projectRouter)
       // TODO: Use request.params.storeKey to activate a store context for each repository

--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -146,8 +146,6 @@ export class CommercetoolsMock {
       )
     } else {
       app.use('/:projectKey', projectRouter)
-      // TODO: Use request.params.storeKey to activate a store context for each repository
-      // so we can either set the store attribute or check against it
       app.use('/:projectKey/in-store/key=:storeKey', projectRouter)
     }
 

--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -139,8 +139,12 @@ export class CommercetoolsMock {
     // Only enable auth middleware if we have enabled this
     if (this.options.enableAuthentication) {
       app.use('/:projectKey', this._oauth2.createMiddleware(), projectRouter)
+      app.use('/:projectKey/in-store/key=:storeKey', this._oauth2.createMiddleware(), projectRouter)
     } else {
       app.use('/:projectKey', projectRouter)
+      // TODO: Use request.params.storeKey to activate a store context for each repository
+      // so we can either set the store attribute or check against it
+      app.use('/:projectKey/in-store/key=:storeKey', projectRouter)
     }
 
     this._projectService = new ProjectService(projectRouter, this._storage)

--- a/src/repositories/cart-discount.ts
+++ b/src/repositories/cart-discount.ts
@@ -18,7 +18,7 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { createTypedMoney } from './helpers'
 
 export class CartDiscountRepository extends AbstractResourceRepository {
@@ -26,7 +26,7 @@ export class CartDiscountRepository extends AbstractResourceRepository {
     return 'cart-discount'
   }
 
-  create(projectKey: string, draft: CartDiscountDraft): CartDiscount {
+  create(context: RepositoryContext, draft: CartDiscountDraft): CartDiscount {
     const resource: CartDiscount = {
       ...getBaseResourceProperties(),
       key: draft.key,
@@ -43,7 +43,7 @@ export class CartDiscountRepository extends AbstractResourceRepository {
       validUntil: draft.validUntil,
       value: this.transformValueDraft(draft.value),
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
@@ -80,42 +80,42 @@ export class CartDiscountRepository extends AbstractResourceRepository {
     Record<
       CartDiscountUpdateAction['action'],
       (
-        projectKey: string,
+        context: RepositoryContext,
         resource: Writable<CartDiscount>,
         action: any
       ) => void
     >
   > = {
     setKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { key }: CartDiscountSetKeyAction
     ) => {
       resource.key = key
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { description }: CartDiscountSetDescriptionAction
     ) => {
       resource.description = description
     },
     setValidFrom: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { validFrom }: CartDiscountSetValidFromAction
     ) => {
       resource.validFrom = validFrom
     },
     setValidUntil: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { validUntil }: CartDiscountSetValidUntilAction
     ) => {
       resource.validUntil = validUntil
     },
     setValidFromAndUntil: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { validFrom, validUntil }: CartDiscountSetValidFromAndUntilAction
     ) => {
@@ -123,14 +123,14 @@ export class CartDiscountRepository extends AbstractResourceRepository {
       resource.validUntil = validUntil
     },
     changeSortOrder: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { sortOrder }: CartDiscountChangeSortOrderAction
     ) => {
       resource.sortOrder = sortOrder
     },
     changeIsActive: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CartDiscount>,
       { isActive }: CartDiscountChangeIsActiveAction
     ) => {

--- a/src/repositories/category.ts
+++ b/src/repositories/category.ts
@@ -16,14 +16,14 @@ import {
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
 import { createCustomFields } from './helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class CategoryRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'category'
   }
 
-  create(projectKey: string, draft: CategoryDraft): Category {
+  create(context: RepositoryContext, draft: CategoryDraft): Category {
     const resource: Category = {
       ...getBaseResourceProperties(),
       key: draft.key,
@@ -44,17 +44,21 @@ export class CategoryRepository extends AbstractResourceRepository {
             sources: d.sources,
             tags: d.tags,
             key: d.key,
-            custom: createCustomFields(draft.custom, projectKey, this._storage),
+            custom: createCustomFields(
+              draft.custom,
+              context.projectKey,
+              this._storage
+            ),
           }
         }) || [],
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   actions = {
     changeAssetName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { assetId, assetKey, name }: CategoryChangeAssetNameAction
     ) => {
@@ -68,21 +72,21 @@ export class CategoryRepository extends AbstractResourceRepository {
       })
     },
     changeSlug: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { slug }: CategoryChangeSlugAction
     ) => {
       resource.slug = slug
     },
     setKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { key }: CategorySetKeyAction
     ) => {
       resource.key = key
     },
     setAssetDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { assetId, assetKey, description }: CategorySetAssetDescriptionAction
     ) => {
@@ -96,7 +100,7 @@ export class CategoryRepository extends AbstractResourceRepository {
       })
     },
     setAssetSources: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { assetId, assetKey, sources }: CategorySetAssetSourcesAction
     ) => {
@@ -110,28 +114,28 @@ export class CategoryRepository extends AbstractResourceRepository {
       })
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { description }: CategorySetDescriptionAction
     ) => {
       resource.description = description
     },
     setMetaDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { metaDescription }: CategorySetMetaDescriptionAction
     ) => {
       resource.metaDescription = metaDescription
     },
     setMetaKeywords: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { metaKeywords }: CategorySetMetaKeywordsAction
     ) => {
       resource.metaKeywords = metaKeywords
     },
     setMetaTitle: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Category>,
       { metaTitle }: CategorySetMetaTitleAction
     ) => {

--- a/src/repositories/channel.ts
+++ b/src/repositories/channel.ts
@@ -4,20 +4,20 @@ import {
   ReferenceTypeId,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class ChannelRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'channel'
   }
 
-  create(projectKey: string, draft: ChannelDraft): Channel {
+  create(context: RepositoryContext, draft: ChannelDraft): Channel {
     const resource: Channel = {
       ...getBaseResourceProperties(),
       key: draft.key,
       roles: draft.roles || [],
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 }

--- a/src/repositories/custom-object.ts
+++ b/src/repositories/custom-object.ts
@@ -4,7 +4,7 @@ import {
   ReferenceTypeId,
 } from '@commercetools/platform-sdk'
 import { checkConcurrentModification } from './errors'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { Writable } from '../types'
 import { getBaseResourceProperties } from '../helpers'
 
@@ -13,9 +13,12 @@ export class CustomObjectRepository extends AbstractResourceRepository {
     return 'key-value-document'
   }
 
-  create(projectKey: string, draft: Writable<CustomObjectDraft>): CustomObject {
+  create(
+    context: RepositoryContext,
+    draft: Writable<CustomObjectDraft>
+  ): CustomObject {
     const current = this.getWithContainerAndKey(
-      projectKey,
+      context,
       draft.container,
       draft.key
     )
@@ -47,14 +50,19 @@ export class CustomObjectRepository extends AbstractResourceRepository {
       value: draft.value,
     }
 
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
-  getWithContainerAndKey(projectKey: string, container: string, key: string) {
-    const items = this._storage.all(projectKey, this.getTypeId()) as Array<
-      CustomObject
-    >
+  getWithContainerAndKey(
+    context: RepositoryContext,
+    container: string,
+    key: string
+  ) {
+    const items = this._storage.all(
+      context.projectKey,
+      this.getTypeId()
+    ) as Array<CustomObject>
     return items.find(item => item.container === container && item.key === key)
   }
 }

--- a/src/repositories/customer-group.ts
+++ b/src/repositories/customer-group.ts
@@ -7,32 +7,32 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class CustomerGroupRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'customer'
   }
-  create(projectKey: string, draft: CustomerGroupDraft): CustomerGroup {
+  create(context: RepositoryContext, draft: CustomerGroupDraft): CustomerGroup {
     const resource: CustomerGroup = {
       ...getBaseResourceProperties(),
       key: draft.key,
       name: draft.groupName,
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   actions = {
     setKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CustomerGroup>,
       { key }: CustomerGroupSetKeyAction
     ) => {
       resource.key = key
     },
     changeName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<CustomerGroup>,
       { name }: CustomerGroupChangeNameAction
     ) => {

--- a/src/repositories/customer.ts
+++ b/src/repositories/customer.ts
@@ -6,14 +6,14 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class CustomerRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'customer'
   }
 
-  create(projectKey: string, draft: CustomerDraft): Customer {
+  create(context: RepositoryContext, draft: CustomerDraft): Customer {
     const resource: Customer = {
       ...getBaseResourceProperties(),
       email: draft.email,
@@ -23,12 +23,16 @@ export class CustomerRepository extends AbstractResourceRepository {
       isEmailVerified: draft.isEmailVerified || false,
       addresses: [],
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
-  getMe(projectKey: string): Customer | undefined {
-    const results = this._storage.query(projectKey, this.getTypeId(), {}) // grab the first customer you can find
+  getMe(context: RepositoryContext): Customer | undefined {
+    const results = this._storage.query(
+      context.projectKey,
+      this.getTypeId(),
+      {}
+    ) // grab the first customer you can find
     if (results.count > 0) {
       return results.results[0] as Customer
     }
@@ -38,7 +42,7 @@ export class CustomerRepository extends AbstractResourceRepository {
 
   actions = {
     changeEmail: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<Customer>,
       { email }: CustomerChangeEmailAction
     ) => {

--- a/src/repositories/discount-code.ts
+++ b/src/repositories/discount-code.ts
@@ -17,14 +17,14 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class DiscountCodeRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'cart-discount'
   }
 
-  create(projectKey: string, draft: DiscountCodeDraft): DiscountCode {
+  create(context: RepositoryContext, draft: DiscountCodeDraft): DiscountCode {
     const resource: DiscountCode = {
       ...getBaseResourceProperties(),
       applicationVersion: 1,
@@ -46,7 +46,7 @@ export class DiscountCodeRepository extends AbstractResourceRepository {
       maxApplications: draft.maxApplications,
       maxApplicationsPerCustomer: draft.maxApplicationsPerCustomer,
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
@@ -54,21 +54,21 @@ export class DiscountCodeRepository extends AbstractResourceRepository {
     Record<
       DiscountCodeUpdateAction['action'],
       (
-        projectKey: string,
+        context: RepositoryContext,
         resource: Writable<DiscountCode>,
         action: any
       ) => void
     >
   > = {
     changeIsActive: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { isActive }: DiscountCodeChangeIsActiveAction
     ) => {
       resource.isActive = isActive
     },
     changeCartDiscounts: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { cartDiscounts }: DiscountCodeChangeCartDiscountsAction
     ) => {
@@ -80,35 +80,35 @@ export class DiscountCodeRepository extends AbstractResourceRepository {
       )
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { description }: DiscountCodeSetDescriptionAction
     ) => {
       resource.description = description
     },
     setCartPredicate: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { cartPredicate }: DiscountCodeSetCartPredicateAction
     ) => {
       resource.cartPredicate = cartPredicate
     },
     setName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { name }: DiscountCodeSetNameAction
     ) => {
       resource.name = name
     },
     setMaxApplications: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { maxApplications }: DiscountCodeSetMaxApplicationsAction
     ) => {
       resource.maxApplications = maxApplications
     },
     setMaxApplicationsPerCustomer: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       {
         maxApplicationsPerCustomer,
@@ -117,21 +117,21 @@ export class DiscountCodeRepository extends AbstractResourceRepository {
       resource.maxApplicationsPerCustomer = maxApplicationsPerCustomer
     },
     setValidFrom: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { validFrom }: DiscountCodeSetValidFromAction
     ) => {
       resource.validFrom = validFrom
     },
     setValidUntil: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { validUntil }: DiscountCodeSetValidUntilAction
     ) => {
       resource.validUntil = validUntil
     },
     setValidFromAndUntil: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<DiscountCode>,
       { validFrom, validUntil }: DiscountCodeSetValidFromAndUntilAction
     ) => {

--- a/src/repositories/extension.ts
+++ b/src/repositories/extension.ts
@@ -10,14 +10,14 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from '../types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class ExtensionRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'extension'
   }
 
-  create(projectKey: string, draft: ExtensionDraft): Extension {
+  create(context: RepositoryContext, draft: ExtensionDraft): Extension {
     const resource: Extension = {
       ...getBaseResourceProperties(),
       key: draft.key,
@@ -25,37 +25,41 @@ export class ExtensionRepository extends AbstractResourceRepository {
       destination: draft.destination,
       triggers: draft.triggers,
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   actions: Record<
     ExtensionUpdateAction['action'],
-    (projectKey: string, resource: Writable<Extension>, action: any) => void
+    (
+      context: RepositoryContext,
+      resource: Writable<Extension>,
+      action: any
+    ) => void
   > = {
     setKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Extension>,
       { key }: ExtensionSetKeyAction
     ) => {
       resource.key = key
     },
     setTimeoutInMs: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Extension>,
       { timeoutInMs }: ExtensionSetTimeoutInMsAction
     ) => {
       resource.timeoutInMs = timeoutInMs
     },
     changeTriggers: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Extension>,
       { triggers }: ExtensionChangeTriggersAction
     ) => {
       resource.triggers = triggers
     },
     changeDestination: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Extension>,
       { destination }: ExtensionChangeDestinationAction
     ) => {

--- a/src/repositories/helpers.ts
+++ b/src/repositories/helpers.ts
@@ -14,6 +14,8 @@ import {
   TypedMoney,
 } from '@commercetools/platform-sdk'
 import { AbstractStorage } from '../storage'
+import { RepositoryContext } from './abstract'
+import { Request } from 'express'
 
 export const createCustomFields = (
   draft: CustomFieldsDraft | undefined,
@@ -95,4 +97,11 @@ export const getReferenceFromResourceIdentifier = <T extends Reference>(
     typeId: resourceIdentifier.typeId,
     id: resource?.id,
   } as unknown) as T
+}
+
+export const getRepositoryContext = (request: Request): RepositoryContext => {
+  return {
+    projectKey: request.params.projectKey,
+    storeKey: request.params.storeKey,
+  }
 }

--- a/src/repositories/inventory-entry.ts
+++ b/src/repositories/inventory-entry.ts
@@ -9,7 +9,7 @@ import {
   ReferenceTypeId,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { createCustomFields } from './helpers'
 import { Writable } from '../types'
 
@@ -18,7 +18,10 @@ export class InventoryEntryRepository extends AbstractResourceRepository {
     return 'inventory-entry'
   }
 
-  create(projectKey: string, draft: InventoryEntryDraft): InventoryEntry {
+  create(
+    context: RepositoryContext,
+    draft: InventoryEntryDraft
+  ): InventoryEntry {
     const resource: InventoryEntry = {
       ...getBaseResourceProperties(),
       sku: draft.sku,
@@ -31,15 +34,19 @@ export class InventoryEntryRepository extends AbstractResourceRepository {
         typeId: 'channel',
         id: draft.supplyChannel?.id ?? '',
       },
-      custom: createCustomFields(draft.custom, projectKey, this._storage),
+      custom: createCustomFields(
+        draft.custom,
+        context.projectKey,
+        this._storage
+      ),
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   actions = {
     changeQuantity: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<InventoryEntry>,
       { quantity }: InventoryEntryChangeQuantityAction
     ) => {
@@ -48,14 +55,14 @@ export class InventoryEntryRepository extends AbstractResourceRepository {
       resource.availableQuantity = quantity
     },
     setExpectedDelivery: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<InventoryEntry>,
       { expectedDelivery }: InventoryEntrySetExpectedDeliveryAction
     ) => {
       resource.expectedDelivery = new Date(expectedDelivery!).toISOString()
     },
     setCustomField: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: InventoryEntry,
       { name, value }: InventoryEntrySetCustomFieldAction
     ) => {
@@ -65,7 +72,7 @@ export class InventoryEntryRepository extends AbstractResourceRepository {
       resource.custom.fields[name] = value
     },
     setCustomType: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<InventoryEntry>,
       { type, fields }: InventoryEntrySetCustomTypeAction
     ) => {
@@ -73,7 +80,7 @@ export class InventoryEntryRepository extends AbstractResourceRepository {
         resource.custom = undefined
       } else {
         const resolvedType = this._storage.getByResourceIdentifier(
-          projectKey,
+          context.projectKey,
           type
         )
         if (!resolvedType) {
@@ -90,7 +97,7 @@ export class InventoryEntryRepository extends AbstractResourceRepository {
       }
     },
     setRestockableInDays: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<InventoryEntry>,
       { restockableInDays }: InventoryEntrySetRestockableInDaysAction
     ) => {

--- a/src/repositories/my-order.ts
+++ b/src/repositories/my-order.ts
@@ -1,0 +1,18 @@
+import assert from 'assert'
+import {
+  CartReference,
+  MyOrderFromCartDraft,
+  Order,
+} from '@commercetools/platform-sdk'
+import { OrderRepository } from './order'
+
+export class MyOrderRepository extends OrderRepository {
+  create(projectKey: string, draft: MyOrderFromCartDraft): Order {
+    assert(draft.id, 'draft.id is missing')
+    const cartIdentifier = {
+      id: draft.id,
+      typeId: 'cart',
+    } as CartReference
+    return this.createFromCart(projectKey, cartIdentifier)
+  }
+}

--- a/src/repositories/my-order.ts
+++ b/src/repositories/my-order.ts
@@ -5,14 +5,15 @@ import {
   Order,
 } from '@commercetools/platform-sdk'
 import { OrderRepository } from './order'
+import { RepositoryContext } from './abstract'
 
 export class MyOrderRepository extends OrderRepository {
-  create(projectKey: string, draft: MyOrderFromCartDraft): Order {
+  create(context: RepositoryContext, draft: MyOrderFromCartDraft): Order {
     assert(draft.id, 'draft.id is missing')
     const cartIdentifier = {
       id: draft.id,
       typeId: 'cart',
     } as CartReference
-    return this.createFromCart(projectKey, cartIdentifier)
+    return this.createFromCart(context, cartIdentifier)
   }
 }

--- a/src/repositories/order.test.ts
+++ b/src/repositories/order.test.ts
@@ -1,10 +1,86 @@
-import { OrderImportDraft } from '@commercetools/platform-sdk'
+import { Cart, OrderImportDraft } from '@commercetools/platform-sdk'
 import { OrderRepository } from './order'
 import { InMemoryStorage } from '../storage'
 
-describe('Order Import', () => {
+describe('Order repository', () => {
   const storage = new InMemoryStorage()
   const repository = new OrderRepository(storage)
+
+  test('create from cart', async () => {
+    const cart: Cart = {
+      id: 'b3875a58-4ab2-4aaa-b399-184ce7561c27',
+      version: 1,
+      createdAt: '2021-09-02T12:23:30.036Z',
+      lastModifiedAt: '2021-09-02T12:23:30.546Z',
+      lineItems: [],
+      customLineItems: [],
+      totalPrice: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 10000,
+        fractionDigits: 2,
+      },
+      cartState: 'Active',
+      taxMode: 'Platform',
+      taxRoundingMode: 'HalfEven',
+      taxCalculationMode: 'UnitPriceLevel',
+      refusedGifts: [],
+      origin: 'Customer',
+    }
+
+    storage.add('dummy', 'cart', cart)
+
+    const result = repository.create(
+      { projectKey: 'dummy' },
+      {
+        cart: {
+          id: cart.id,
+          typeId: 'cart',
+        },
+        version: cart.version,
+      }
+    )
+    expect(result.cart?.id).toBe(cart.id)
+  })
+
+  test('create from cart - in store', async () => {
+    const cart: Cart = {
+      id: 'b3875a58-4ab2-4aaa-b399-184ce7561c27',
+      version: 1,
+      createdAt: '2021-09-02T12:23:30.036Z',
+      lastModifiedAt: '2021-09-02T12:23:30.546Z',
+      lineItems: [],
+      customLineItems: [],
+      totalPrice: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 10000,
+        fractionDigits: 2,
+      },
+      cartState: 'Active',
+      taxMode: 'Platform',
+      taxRoundingMode: 'HalfEven',
+      taxCalculationMode: 'UnitPriceLevel',
+      refusedGifts: [],
+      origin: 'Customer',
+    }
+
+    storage.add('dummy', 'cart', cart)
+
+    const result = repository.create(
+      { projectKey: 'dummy', storeKey: 'some-store' },
+      {
+        cart: {
+          id: cart.id,
+          typeId: 'cart',
+        },
+        version: cart.version,
+      }
+    )
+    expect(result.cart?.id).toBe(cart.id)
+    expect(result.store?.key).toBe('some-store')
+  })
+
   test('import exiting product', async () => {
     storage.add('dummy', 'product', {
       id: '15fc56ba-a74e-4cf8-b4b0-bada5c101541',
@@ -150,7 +226,7 @@ describe('Order Import', () => {
       ],
     }
 
-    repository.import('dummy', draft)
+    repository.import({ projectKey: 'dummy' }, draft)
   })
   /*
   test('import non exiting product', async () => {

--- a/src/repositories/product-projection.ts
+++ b/src/repositories/product-projection.ts
@@ -6,7 +6,7 @@ import {
   ProductVariantDraft,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { RepositoryTypes } from '../types'
 import { parseFilterExpression } from '../lib/filterParser'
 
@@ -15,7 +15,7 @@ export class ProductProjectionRepository extends AbstractResourceRepository {
     return 'product-projection'
   }
 
-  create(projectKey: string, draft: ProductDraft): ProductProjection {
+  create(context: RepositoryContext, draft: ProductDraft): ProductProjection {
     if (!draft.masterVariant) {
       throw new Error(
         `must provider mastervariant for product projection with key ${draft.key}`
@@ -44,16 +44,16 @@ export class ProductProjectionRepository extends AbstractResourceRepository {
       searchKeywords: draft.searchKeywords,
     }
 
-    this.save(projectKey, resource)
+    this.save(context, resource)
 
     return resource
   }
 
-  search(projectKey: string, query: ParsedQs) {
+  search(context: RepositoryContext, query: ParsedQs) {
     const filter = (query['filter.query'] ?? query.filter) as any
     const wherePredicate = filter ? parseFilterExpression(filter) : undefined
 
-    const results = this._storage.query(projectKey, this.getTypeId(), {
+    const results = this._storage.query(context.projectKey, this.getTypeId(), {
       where: wherePredicate,
       offset: query.offset ? Number(query.offset) : undefined,
       limit: query.limit ? Number(query.limit) : undefined,

--- a/src/repositories/product-type.ts
+++ b/src/repositories/product-type.ts
@@ -10,7 +10,7 @@ import {
   ProductTypeUpdateAction,
   ReferenceTypeId,
 } from '@commercetools/platform-sdk'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { Writable } from 'types'
 
 export class ProductTypeRepository extends AbstractResourceRepository {
@@ -18,23 +18,23 @@ export class ProductTypeRepository extends AbstractResourceRepository {
     return 'product-type'
   }
 
-  create(projectKey: string, draft: ProductTypeDraft): ProductType {
+  create(context: RepositoryContext, draft: ProductTypeDraft): ProductType {
     const resource: ProductType = {
       ...getBaseResourceProperties(),
       key: draft.key,
       name: draft.name,
       description: draft.description,
       attributes: (draft.attributes ?? []).map(a =>
-        this.attributeDefinitionFromAttributeDefinitionDraft(projectKey, a)
+        this.attributeDefinitionFromAttributeDefinitionDraft(context, a)
       ),
     }
 
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   attributeDefinitionFromAttributeDefinitionDraft = (
-    _projectKey: string,
+    _context: RepositoryContext,
     draft: AttributeDefinitionDraft
   ): AttributeDefinition => ({
     ...draft,
@@ -43,8 +43,8 @@ export class ProductTypeRepository extends AbstractResourceRepository {
     isSearchable: draft.isSearchable ?? true,
   })
 
-  getWithKey(projectKey: string, key: string): ProductType | undefined {
-    const result = this._storage.query(projectKey, this.getTypeId(), {
+  getWithKey(context: RepositoryContext, key: string): ProductType | undefined {
+    const result = this._storage.query(context.projectKey, this.getTypeId(), {
       where: [`key="${key}"`],
     })
     if (result.count === 1) {
@@ -62,11 +62,15 @@ export class ProductTypeRepository extends AbstractResourceRepository {
   actions: Partial<
     Record<
       ProductTypeUpdateAction['action'],
-      (projectKey: string, resource: Writable<ProductType>, action: any) => void
+      (
+        context: RepositoryContext,
+        resource: Writable<ProductType>,
+        action: any
+      ) => void
     >
   > = {
     changeLocalizedEnumValueLabel: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<ProductType>,
       {
         attributeName,
@@ -95,7 +99,7 @@ export class ProductTypeRepository extends AbstractResourceRepository {
       })
     },
     changeLabel: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<ProductType>,
       { attributeName, label }: ProductTypeChangeLabelAction
     ) => {

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -10,7 +10,7 @@ import {
   ReferenceTypeId,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { Writable } from '../types'
 
 export class ProductRepository extends AbstractResourceRepository {
@@ -18,7 +18,7 @@ export class ProductRepository extends AbstractResourceRepository {
     return 'product'
   }
 
-  create(projectKey: string, draft: ProductDraft): Product {
+  create(context: RepositoryContext, draft: ProductDraft): Product {
     const productData = {
       name: draft.name,
       slug: draft.slug,
@@ -47,14 +47,14 @@ export class ProductRepository extends AbstractResourceRepository {
       },
     }
 
-    this.save(projectKey, resource)
+    this.save(context, resource)
 
     return resource
   }
 
   actions = {
     publish: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Product>,
       { scope }: ProductPublishAction
     ) => {
@@ -67,7 +67,7 @@ export class ProductRepository extends AbstractResourceRepository {
       resource.masterData.published = true
     },
     setAttribute: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Product>,
       { variantId, sku, name, value, staged }: ProductSetAttributeAction
     ) => {

--- a/src/repositories/project.ts
+++ b/src/repositories/project.ts
@@ -17,12 +17,12 @@ import { InvalidOperationError } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { checkConcurrentModification } from './errors'
 import { CommercetoolsError } from '../exceptions'
-import { AbstractRepository } from './abstract'
+import { AbstractRepository, RepositoryContext } from './abstract'
 import { maskSecretValue } from '../lib/masking'
 
 export class ProjectRepository extends AbstractRepository {
-  get(projectKey: string): Project | null {
-    const resource = this._storage.getProject(projectKey)
+  get(context: RepositoryContext): Project | null {
+    const resource = this._storage.getProject(context.projectKey)
     const masked = maskSecretValue<Project>(
       resource,
       'externalOAuth.authorizationHeader'
@@ -30,8 +30,8 @@ export class ProjectRepository extends AbstractRepository {
     return masked
   }
 
-  save(projectKey: string, resource: Project) {
-    const current = this.get(projectKey)
+  save(context: RepositoryContext, resource: Project) {
+    const current = this.get(context)
 
     if (current) {
       checkConcurrentModification(current, resource.version)
@@ -55,46 +55,50 @@ export class ProjectRepository extends AbstractRepository {
   actions: Partial<
     Record<
       ProjectUpdateAction['action'],
-      (projectKey: string, resource: Writable<Project>, action: any) => void
+      (
+        context: RepositoryContext,
+        resource: Writable<Project>,
+        action: any
+      ) => void
     >
   > = {
     changeName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { name }: ProjectChangeNameAction
     ) => {
       resource.name = name
     },
     changeCurrencies: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { currencies }: ProjectChangeCurrenciesAction
     ) => {
       resource.currencies = currencies
     },
     changeCountries: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { countries }: ProjectChangeCountriesAction
     ) => {
       resource.countries = countries
     },
     changeLanguages: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { languages }: ProjectChangeLanguagesAction
     ) => {
       resource.languages = languages
     },
     changeMessagesEnabled: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { messagesEnabled }: ProjectChangeMessagesEnabledAction
     ) => {
       resource.messages.enabled = messagesEnabled
     },
     changeProductSearchIndexingEnabled: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { enabled }: ProjectChangeProductSearchIndexingEnabledAction
     ) => {
@@ -107,7 +111,7 @@ export class ProjectRepository extends AbstractRepository {
       resource.searchIndexing.products.lastModifiedAt = new Date().toISOString()
     },
     changeOrderSearchStatus: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { status }: ProjectChangeOrderSearchStatusAction
     ) => {
@@ -118,21 +122,21 @@ export class ProjectRepository extends AbstractRepository {
       resource.searchIndexing.orders.lastModifiedAt = new Date().toISOString()
     },
     setShippingRateInputType: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { shippingRateInputType }: ProjectSetShippingRateInputTypeAction
     ) => {
       resource.shippingRateInputType = shippingRateInputType
     },
     setExternalOAuth: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { externalOAuth }: ProjectSetExternalOAuthAction
     ) => {
       resource.externalOAuth = externalOAuth
     },
     changeCountryTaxRateFallbackEnabled: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       {
         countryTaxRateFallbackEnabled,
@@ -141,7 +145,7 @@ export class ProjectRepository extends AbstractRepository {
       resource.carts.countryTaxRateFallbackEnabled = countryTaxRateFallbackEnabled
     },
     changeCartsConfiguration: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Project>,
       { cartsConfiguration }: ProjectChangeCartsConfigurationAction
     ) => {

--- a/src/repositories/shipping-method.ts
+++ b/src/repositories/shipping-method.ts
@@ -24,7 +24,7 @@ import {
   ZoneReference,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { Writable } from 'types'
 import deepEqual from 'deep-equal'
 
@@ -33,32 +33,39 @@ export class ShippingMethodRepository extends AbstractResourceRepository {
     return 'shipping-method'
   }
 
-  create(projectKey: string, draft: ShippingMethodDraft): ShippingMethod {
+  create(
+    context: RepositoryContext,
+    draft: ShippingMethodDraft
+  ): ShippingMethod {
     const resource: ShippingMethod = {
       ...getBaseResourceProperties(),
       ...draft,
       taxCategory: getReferenceFromResourceIdentifier(
         draft.taxCategory,
-        projectKey,
+        context.projectKey,
         this._storage
       ),
       zoneRates: draft.zoneRates?.map(z =>
-        this._transformZoneRateDraft(projectKey, z)
+        this._transformZoneRateDraft(context, z)
       ),
-      custom: createCustomFields(draft.custom, projectKey, this._storage),
+      custom: createCustomFields(
+        draft.custom,
+        context.projectKey,
+        this._storage
+      ),
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   private _transformZoneRateDraft = (
-    projectKey: string,
+    context: RepositoryContext,
     draft: ZoneRateDraft
   ): ZoneRate => ({
     ...draft,
     zone: getReferenceFromResourceIdentifier<ZoneReference>(
       draft.zone,
-      projectKey,
+      context.projectKey,
       this._storage
     ),
     shippingRates: draft.shippingRates?.map(this._transformShippingRate),
@@ -76,14 +83,14 @@ export class ShippingMethodRepository extends AbstractResourceRepository {
     Record<
       ShippingMethodUpdateAction['action'],
       (
-        projectKey: string,
+        context: RepositoryContext,
         resource: Writable<ShippingMethod>,
         action: any
       ) => void
     >
   > = {
     addShippingRate: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { shippingRate, zone }: ShippingMethodAddShippingRateAction
     ) => {
@@ -104,7 +111,7 @@ export class ShippingMethodRepository extends AbstractResourceRepository {
       })
     },
     removeShippingRate: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { shippingRate, zone }: ShippingMethodAddShippingRateAction
     ) => {
@@ -119,13 +126,13 @@ export class ShippingMethodRepository extends AbstractResourceRepository {
       })
     },
     addZone: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { zone }: ShippingMethodAddZoneAction
     ) => {
       const zoneReference = getReferenceFromResourceIdentifier<ZoneReference>(
         zone,
-        projectKey,
+        context.projectKey,
         this._storage
       )
 
@@ -139,7 +146,7 @@ export class ShippingMethodRepository extends AbstractResourceRepository {
       })
     },
     removeZone: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { zone }: ShippingMethodRemoveZoneAction
     ) => {
@@ -148,42 +155,42 @@ export class ShippingMethodRepository extends AbstractResourceRepository {
       })
     },
     setKey: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { key }: ShippingMethodSetKeyAction
     ) => {
       resource.key = key
     },
     setDescription: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { description }: ShippingMethodSetDescriptionAction
     ) => {
       resource.description = description
     },
     setLocalizedDescription: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { localizedDescription }: ShippingMethodSetLocalizedDescriptionAction
     ) => {
       resource.localizedDescription = localizedDescription
     },
     setPredicate: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { predicate }: ShippingMethodSetPredicateAction
     ) => {
       resource.predicate = predicate
     },
     changeIsDefault: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { isDefault }: ShippingMethodChangeIsDefaultAction
     ) => {
       resource.isDefault = isDefault
     },
     changeName: (
-      _projectKey: string,
+      _context: RepositoryContext,
       resource: Writable<ShippingMethod>,
       { name }: ShippingMethodChangeNameAction
     ) => {

--- a/src/repositories/shopping-list.ts
+++ b/src/repositories/shopping-list.ts
@@ -5,7 +5,7 @@ import {
   ShoppingListDraft,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import {
   createCustomFields,
   getReferenceFromResourceIdentifier,
@@ -15,13 +15,17 @@ export class ShoppingListRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'shopping-list'
   }
-  create(projectKey: string, draft: ShoppingListDraft): ShoppingList {
+  create(context: RepositoryContext, draft: ShoppingListDraft): ShoppingList {
     // const product =
 
     const resource: ShoppingList = {
       ...getBaseResourceProperties(),
       ...draft,
-      custom: createCustomFields(draft.custom, projectKey, this._storage),
+      custom: createCustomFields(
+        draft.custom,
+        context.projectKey,
+        this._storage
+      ),
       textLineItems: [],
       lineItems: draft.lineItems?.map(e => ({
         ...getBaseResourceProperties(),
@@ -31,12 +35,12 @@ export class ShoppingListRepository extends AbstractResourceRepository {
         name: {},
         quantity: e.quantity ?? 1,
         productType: { typeId: 'product-type', id: '' },
-        custom: createCustomFields(e.custom, projectKey, this._storage),
+        custom: createCustomFields(e.custom, context.projectKey, this._storage),
       })),
       customer: draft.customer
         ? getReferenceFromResourceIdentifier<CustomerReference>(
             draft.customer,
-            projectKey,
+            context.projectKey,
             this._storage
           )
         : undefined,
@@ -44,7 +48,7 @@ export class ShoppingListRepository extends AbstractResourceRepository {
         ? { typeId: 'store', key: draft.store.key! }
         : undefined,
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 }

--- a/src/repositories/state.ts
+++ b/src/repositories/state.ts
@@ -10,7 +10,7 @@ import {
   StateSetRolesAction,
   StateUpdateAction,
 } from '@commercetools/platform-sdk'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { Writable } from 'types'
 
 export class StateRepository extends AbstractResourceRepository {
@@ -18,50 +18,54 @@ export class StateRepository extends AbstractResourceRepository {
     return 'state'
   }
 
-  create(projectKey: string, draft: StateDraft): State {
+  create(context: RepositoryContext, draft: StateDraft): State {
     const resource: State = {
       ...getBaseResourceProperties(),
       ...draft,
       builtIn: false,
       initial: draft.initial || false,
       transitions: (draft.transitions || []).map(t =>
-        getReferenceFromResourceIdentifier(t, projectKey, this._storage)
+        getReferenceFromResourceIdentifier(t, context.projectKey, this._storage)
       ),
     }
 
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   actions: Partial<
     Record<
       StateUpdateAction['action'],
-      (projectKey: string, resource: Writable<State>, action: any) => void
+      (
+        context: RepositoryContext,
+        resource: Writable<State>,
+        action: any
+      ) => void
     >
   > = {
     changeKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<State>,
       { key }: StateChangeKeyAction
     ) => {
       resource.key = key
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<State>,
       { description }: StateSetDescriptionAction
     ) => {
       resource.description = description
     },
     setName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<State>,
       { name }: StateSetNameAction
     ) => {
       resource.name = name
     },
     setRoles: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<State>,
       { roles }: StateSetRolesAction
     ) => {

--- a/src/repositories/subscription.ts
+++ b/src/repositories/subscription.ts
@@ -6,13 +6,13 @@ import {
 } from '@commercetools/platform-sdk'
 import { CommercetoolsError } from '../exceptions'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class SubscriptionRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'subscription'
   }
-  create(projectKey: string, draft: SubscriptionDraft): Subscription {
+  create(context: RepositoryContext, draft: SubscriptionDraft): Subscription {
     // TODO: We could actually test this here by using the aws sdk. For now
     // hardcode a failed check when account id is 0000000000
     if (draft.destination.type === 'SQS') {
@@ -44,7 +44,7 @@ export class SubscriptionRepository extends AbstractResourceRepository {
       messages: draft.messages || [],
       status: 'Healthy',
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 }

--- a/src/repositories/tax-category.ts
+++ b/src/repositories/tax-category.ts
@@ -13,7 +13,7 @@ import {
   TaxRateDraft,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 import { v4 as uuidv4 } from 'uuid'
 import { Writable } from 'types'
 
@@ -22,13 +22,13 @@ export class TaxCategoryRepository extends AbstractResourceRepository {
     return 'tax-category'
   }
 
-  create(projectKey: string, draft: TaxCategoryDraft): TaxCategory {
+  create(context: RepositoryContext, draft: TaxCategoryDraft): TaxCategory {
     const resource: TaxCategory = {
       ...getBaseResourceProperties(),
       ...draft,
       rates: draft.rates?.map(this.taxRateFromTaxRateDraft) || [],
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
@@ -38,8 +38,8 @@ export class TaxCategoryRepository extends AbstractResourceRepository {
     amount: draft.amount || 0,
   })
 
-  getWithKey(projectKey: string, key: string): TaxCategory | undefined {
-    const result = this._storage.query(projectKey, this.getTypeId(), {
+  getWithKey(context: RepositoryContext, key: string): TaxCategory | undefined {
+    const result = this._storage.query(context.projectKey, this.getTypeId(), {
       where: [`key="${key}"`],
     })
     if (result.count === 1) {
@@ -57,11 +57,15 @@ export class TaxCategoryRepository extends AbstractResourceRepository {
   actions: Partial<
     Record<
       TaxCategoryUpdateAction['action'],
-      (projectKey: string, resource: Writable<TaxCategory>, action: any) => void
+      (
+        context: RepositoryContext,
+        resource: Writable<TaxCategory>,
+        action: any
+      ) => void
     >
   > = {
     addTaxRate: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<TaxCategory>,
       { taxRate }: TaxCategoryAddTaxRateAction
     ) => {
@@ -71,7 +75,7 @@ export class TaxCategoryRepository extends AbstractResourceRepository {
       resource.rates.push(this.taxRateFromTaxRateDraft(taxRate))
     },
     removeTaxRate: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<TaxCategory>,
       { taxRateId }: TaxCategoryRemoveTaxRateAction
     ) => {
@@ -83,7 +87,7 @@ export class TaxCategoryRepository extends AbstractResourceRepository {
       })
     },
     replaceTaxRate: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<TaxCategory>,
       { taxRateId, taxRate }: TaxCategoryReplaceTaxRateAction
     ) => {
@@ -100,21 +104,21 @@ export class TaxCategoryRepository extends AbstractResourceRepository {
       }
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<TaxCategory>,
       { description }: TaxCategorySetDescriptionAction
     ) => {
       resource.description = description
     },
     setKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<TaxCategory>,
       { key }: TaxCategorySetKeyAction
     ) => {
       resource.key = key
     },
     changeName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<TaxCategory>,
       { name }: TaxCategoryChangeNameAction
     ) => {

--- a/src/repositories/type.ts
+++ b/src/repositories/type.ts
@@ -14,14 +14,14 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class TypeRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'type'
   }
 
-  create(projectKey: string, draft: TypeDraft): Type {
+  create(context: RepositoryContext, draft: TypeDraft): Type {
     const resource: Type = {
       ...getBaseResourceProperties(),
       key: draft.key,
@@ -30,24 +30,28 @@ export class TypeRepository extends AbstractResourceRepository {
       fieldDefinitions: draft.fieldDefinitions || [],
       description: draft.description,
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
   actions: Partial<
     Record<
       TypeUpdateAction['action'],
-      (projectKey: string, resource: Writable<Type>, action: any) => void
+      (
+        context: RepositoryContext,
+        resource: Writable<Type>,
+        action: any
+      ) => void
     >
   > = {
     addFieldDefinition: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { fieldDefinition }: TypeAddFieldDefinitionAction
     ) => {
       resource.fieldDefinitions.push(fieldDefinition)
     },
     removeFieldDefinition: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { fieldName }: TypeRemoveFieldDefinitionAction
     ) => {
@@ -56,21 +60,21 @@ export class TypeRepository extends AbstractResourceRepository {
       })
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { description }: TypeSetDescriptionAction
     ) => {
       resource.description = description
     },
     changeName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { name }: TypeChangeNameAction
     ) => {
       resource.name = name
     },
     changeFieldDefinitionOrder: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { fieldNames }: TypeChangeFieldDefinitionOrderAction
     ) => {
@@ -99,7 +103,7 @@ export class TypeRepository extends AbstractResourceRepository {
       resource.fieldDefinitions.push(...current)
     },
     addEnumValue: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { fieldName, value }: TypeAddEnumValueAction
     ) => {
@@ -120,7 +124,7 @@ export class TypeRepository extends AbstractResourceRepository {
       })
     },
     changeEnumValueLabel: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Type>,
       { fieldName, value }: TypeChangeEnumValueLabelAction
     ) => {

--- a/src/repositories/zone.ts
+++ b/src/repositories/zone.ts
@@ -11,14 +11,14 @@ import {
 } from '@commercetools/platform-sdk'
 import { Writable } from 'types'
 import { getBaseResourceProperties } from '../helpers'
-import { AbstractResourceRepository } from './abstract'
+import { AbstractResourceRepository, RepositoryContext } from './abstract'
 
 export class ZoneRepository extends AbstractResourceRepository {
   getTypeId(): ReferenceTypeId {
     return 'zone'
   }
 
-  create(projectKey: string, draft: ZoneDraft): Zone {
+  create(context: RepositoryContext, draft: ZoneDraft): Zone {
     const resource: Zone = {
       ...getBaseResourceProperties(),
       key: draft.key,
@@ -26,25 +26,29 @@ export class ZoneRepository extends AbstractResourceRepository {
       name: draft.name,
       description: draft.description,
     }
-    this.save(projectKey, resource)
+    this.save(context, resource)
     return resource
   }
 
   actions: Partial<
     Record<
       ZoneUpdateAction['action'],
-      (projectKey: string, resource: Writable<Zone>, action: any) => void
+      (
+        context: RepositoryContext,
+        resource: Writable<Zone>,
+        action: any
+      ) => void
     >
   > = {
     addLocation: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Zone>,
       { location }: ZoneAddLocationAction
     ) => {
       resource.locations.push(location)
     },
     removeLocation: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Zone>,
       { location }: ZoneRemoveLocationAction
     ) => {
@@ -55,21 +59,21 @@ export class ZoneRepository extends AbstractResourceRepository {
       })
     },
     changeName: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Zone>,
       { name }: ZoneChangeNameAction
     ) => {
       resource.name = name
     },
     setDescription: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Zone>,
       { description }: ZoneSetDescriptionAction
     ) => {
       resource.description = description
     },
     setKey: (
-      projectKey: string,
+      context: RepositoryContext,
       resource: Writable<Zone>,
       { key }: ZoneSetKeyAction
     ) => {

--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -4,6 +4,7 @@ import { CartRepository } from '../repositories/cart'
 import { AbstractStorage } from '../storage'
 import { Cart, CartDraft, Order } from '@commercetools/platform-sdk'
 import { OrderRepository } from '../repositories/order'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class CartService extends AbstractService {
   public repository: CartRepository
@@ -21,17 +22,13 @@ export class CartService extends AbstractService {
 
   extraRoutes(parent: Router) {
     parent.post('/replicate', (request, response) => {
+      const context = getRepositoryContext(request)
+
       // @ts-ignore
       const cartOrOrder: Cart | Order | null =
         request.body.reference.typeId === 'order'
-          ? this.orderRepository.get(
-              request.params.projectKey,
-              request.body.reference.id
-            )
-          : this.repository.get(
-              request.params.projectKey,
-              request.body.reference.id
-            )
+          ? this.orderRepository.get(context, request.body.reference.id)
+          : this.repository.get(context, request.body.reference.id)
 
       if (!cartOrOrder) {
         return response.status(400).send()
@@ -50,10 +47,7 @@ export class CartService extends AbstractService {
         }),
       }
 
-      const newCart = this.repository.create(
-        request.params.projectKey,
-        cartDraft
-      )
+      const newCart = this.repository.create(context, cartDraft)
 
       return response.status(200).send(newCart)
     })

--- a/src/services/custom-object.ts
+++ b/src/services/custom-object.ts
@@ -3,6 +3,7 @@ import { Request, Response, Router } from 'express'
 import { CustomObjectRepository } from '../repositories/custom-object'
 import { AbstractStorage } from '../storage'
 import { CustomObjectDraft } from '@commercetools/platform-sdk'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class CustomObjectService extends AbstractService {
   public repository: CustomObjectRepository
@@ -24,7 +25,7 @@ export class CustomObjectService extends AbstractService {
 
   getWithContainerAndKey(request: Request, response: Response) {
     const result = this.repository.getWithContainerAndKey(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.params.container,
       request.params.key
     )
@@ -42,13 +43,13 @@ export class CustomObjectService extends AbstractService {
       container: request.params.container,
     }
 
-    const result = this.repository.create(request.params.projectKey, draft)
+    const result = this.repository.create(getRepositoryContext(request), draft)
     return response.status(200).send(result)
   }
 
   deleteWithContainerAndKey(request: Request, response: Response) {
     const current = this.repository.getWithContainerAndKey(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.params.container,
       request.params.key
     )
@@ -57,7 +58,10 @@ export class CustomObjectService extends AbstractService {
       return response.status(404).send('Not Found')
     }
 
-    const result = this.repository.delete(request.params.projectKey, current.id)
+    const result = this.repository.delete(
+      getRepositoryContext(request),
+      current.id
+    )
 
     return response.status(200).send(result)
   }

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -4,6 +4,7 @@ import { CustomerRepository } from '../repositories/customer'
 import { AbstractStorage } from '../storage'
 import { getBaseResourceProperties } from '../helpers'
 import { v4 as uuidv4 } from 'uuid'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class CustomerService extends AbstractService {
   public repository: CustomerRepository
@@ -19,11 +20,13 @@ export class CustomerService extends AbstractService {
 
   extraRoutes(parent: Router) {
     parent.post('/password-token', (request, response) => {
-      const customer = this.repository.query(request.params.projectKey, {
+      const customer = this.repository.query(getRepositoryContext(request), {
         where: [`email="${request.body.email}"`],
       })
+      // @ts-ignore
       const ttlMinutes: number = request.params.ttlMinutes
-        ? +request.params.ttlMinutes
+        ? // @ts-ignore
+          +request.params.ttlMinutes
         : 34560
       const { version, ...rest } = getBaseResourceProperties()
 

--- a/src/services/my-customer.ts
+++ b/src/services/my-customer.ts
@@ -2,6 +2,7 @@ import AbstractService from './abstract'
 import { Request, Response, Router } from 'express'
 import { AbstractStorage } from '../storage'
 import { CustomerRepository } from '../repositories/customer'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class MyCustomerService extends AbstractService {
   public repository: CustomerRepository
@@ -32,7 +33,7 @@ export class MyCustomerService extends AbstractService {
   }
 
   getMe(request: Request, response: Response) {
-    const resource = this.repository.getMe(request.params.projectKey)
+    const resource = this.repository.getMe(getRepositoryContext(request))
     if (!resource) {
       return response.status(404).send('Not found')
     }
@@ -41,7 +42,10 @@ export class MyCustomerService extends AbstractService {
 
   signUp(request: Request, response: Response) {
     const draft = request.body
-    const resource = this.repository.create(request.params.projectKey, draft)
+    const resource = this.repository.create(
+      getRepositoryContext(request),
+      draft
+    )
     const result = this._expandWithId(request, resource.id)
     return response.status(this.createStatusCode).send({ customer: result })
   }
@@ -50,7 +54,7 @@ export class MyCustomerService extends AbstractService {
     const { email, password } = request.body
     const encodedPassword = Buffer.from(password).toString('base64')
 
-    const result = this.repository.query(request.params.projectKey, {
+    const result = this.repository.query(getRepositoryContext(request), {
       where: [`email = "${email}"`, `password = "${encodedPassword}"`],
     })
 

--- a/src/services/my-order.ts
+++ b/src/services/my-order.ts
@@ -1,14 +1,14 @@
 import AbstractService from './abstract'
 import { Router } from 'express'
 import { AbstractStorage } from '../storage'
-import { OrderRepository } from '../repositories/order'
+import { MyOrderRepository } from '../repositories/my-order'
 
 export class MyOrderService extends AbstractService {
-  public repository: OrderRepository
+  public repository: MyOrderRepository
 
   constructor(parent: Router, storage: AbstractStorage) {
     super(parent)
-    this.repository = new OrderRepository(storage)
+    this.repository = new MyOrderRepository(storage)
   }
 
   getBasePath() {

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -2,6 +2,7 @@ import AbstractService from './abstract'
 import { Request, Response, Router } from 'express'
 import { OrderRepository } from '../repositories/order'
 import { AbstractStorage } from '../storage'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class OrderService extends AbstractService {
   public repository: OrderRepository
@@ -23,7 +24,7 @@ export class OrderService extends AbstractService {
   import(request: Request, response: Response) {
     const importDraft = request.body
     const resource = this.repository.import(
-      request.params.projectKey,
+      getRepositoryContext(request),
       importDraft
     )
     return response.status(200).send(resource)
@@ -31,7 +32,7 @@ export class OrderService extends AbstractService {
 
   getWithOrderNumber(request: Request, response: Response) {
     const resource = this.repository.getWithOrderNumber(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.params.orderNumber,
       request.query
     )

--- a/src/services/product-projection.ts
+++ b/src/services/product-projection.ts
@@ -2,6 +2,7 @@ import { ProductProjectionRepository } from './../repositories/product-projectio
 import AbstractService from './abstract'
 import { AbstractStorage } from '../storage'
 import { Request, Response, Router } from 'express'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class ProductProjectionService extends AbstractService {
   public repository: ProductProjectionRepository
@@ -21,7 +22,7 @@ export class ProductProjectionService extends AbstractService {
 
   search(request: Request, response: Response) {
     const resource = this.repository.search(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.query
     )
     return response.status(200).send(resource)

--- a/src/services/product-type.ts
+++ b/src/services/product-type.ts
@@ -2,6 +2,7 @@ import { ProductTypeRepository } from '../repositories/product-type'
 import AbstractService from './abstract'
 import { Request, Response, Router } from 'express'
 import { AbstractStorage } from '../storage'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class ProductTypeService extends AbstractService {
   public repository: ProductTypeRepository
@@ -21,7 +22,7 @@ export class ProductTypeService extends AbstractService {
 
   getWithKey(request: Request, response: Response) {
     const resource = this.repository.getWithKey(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.params.key
     )
     if (resource) {

--- a/src/services/project.ts
+++ b/src/services/project.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express'
 import { AbstractStorage } from '../storage'
 import { ProjectRepository } from '../repositories/project'
 import { Update } from '@commercetools/platform-sdk'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class ProjectService {
   public repository: ProjectRepository
@@ -19,20 +20,20 @@ export class ProjectService {
 
   get(request: Request, response: Response) {
     const projectKey = request.params.projectKey
-    const project = this.repository.get(projectKey)
+    const project = this.repository.get(getRepositoryContext(request))
     return response.status(200).send(project)
   }
 
   post(request: Request, response: Response) {
     const updateRequest: Update = request.body
-    const project = this.repository.get(request.params.projectKey)
+    const project = this.repository.get(getRepositoryContext(request))
 
     if (!project) {
       return response.status(404).send({})
     }
 
     this.repository.processUpdateActions(
-      request.params.projectKey,
+      getRepositoryContext(request),
       project,
       updateRequest.actions
     )

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -2,6 +2,7 @@ import AbstractService from './abstract'
 import { Router, Request, Response } from 'express'
 import { StoreRepository } from '../repositories/store'
 import { AbstractStorage } from '../storage'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class StoreService extends AbstractService {
   public repository: StoreRepository
@@ -21,7 +22,7 @@ export class StoreService extends AbstractService {
 
   getWithKey(request: Request, response: Response) {
     const resource = this.repository.getWithKey(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.params.key
     )
     if (resource) {

--- a/src/services/tax-category.ts
+++ b/src/services/tax-category.ts
@@ -2,6 +2,7 @@ import { TaxCategoryRepository } from '../repositories/tax-category'
 import AbstractService from './abstract'
 import { AbstractStorage } from '../storage'
 import { Request, Response, Router } from 'express'
+import { getRepositoryContext } from 'repositories/helpers'
 
 export class TaxCategoryService extends AbstractService {
   public repository: TaxCategoryRepository
@@ -21,7 +22,7 @@ export class TaxCategoryService extends AbstractService {
 
   getWithKey(request: Request, response: Response) {
     const resource = this.repository.getWithKey(
-      request.params.projectKey,
+      getRepositoryContext(request),
       request.params.key
     )
     if (resource) {


### PR DESCRIPTION
- Adds `in-store` paths to all endpoints
- Refactor the arguments to repository actions; instead of `projectKey` it receives a `RepositoryContext` which contains the projectKey and optional storeKey
- Later, we can further improve this to take into account the `storeKey` on `storage` level. For now, used only in the order create functionality