### PR TITLE
product_discount: Set undefined if the provided localized string object is empty

### DIFF
--- a/src/repositories/product-discount.ts
+++ b/src/repositories/product-discount.ts
@@ -114,7 +114,11 @@ export class ProductDiscountRepository extends AbstractResourceRepository {
       resource: Writable<ProductDiscount>,
       { description }: ProductDiscountSetDescriptionAction
     ) => {
-      resource.description = description
+      if (description && Object.keys(description).length > 0) {
+        resource.description = description
+      } else {
+        resource.description = undefined
+      }
     },
     changeName: (
       context: RepositoryContext,


### PR DESCRIPTION
This seems to be how CT works.

Related https://github.com/labd/terraform-provider-commercetools/pull/266