### PR TITLE
feat(package): use exports syntax for cjs and mjs output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "dist",
     "src"
   ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
   "engines": {
     "node": ">=14"
   },

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,16 +1,12 @@
 import { defineConfig } from 'tsup'
 
-const commonConfig = {
-  clean: true,
-  splitting: false,
-  dts: true,
-  sourcemap: true,
-}
-
 export default defineConfig([
   {
     entry: ['src/index.ts'],
-    ...commonConfig,
+    clean: true,
+    splitting: false,
+    dts: true,
+    sourcemap: true,
     format: ['cjs', 'esm', 'iife'],
     outDir: 'dist',
   },


### PR DESCRIPTION
The exports syntax is used to define which files are used for commonjs
and which ones for esmodules.

I have also removed the commonConfig and added it defineConfig since it's used once
