### PR TITLE
Add setAuthenticationMode update action to customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.2 (unreleased)
+- Added support for updating `authenticationMode` of a customer
+
 # 0.9.1 (08-09-2022)
 
 - Added boolean parsing logic for predicates.

--- a/src/services/customer.test.ts
+++ b/src/services/customer.test.ts
@@ -12,8 +12,10 @@ describe('Customer Update Actions', () => {
       ...getBaseResourceProperties(),
       id: 'customer-uuid',
       email: 'user@example.com',
+      password: 'supersecret',
       addresses: [],
       isEmailVerified: true,
+      authenticationMode: "Password", //default in Commercetools
       version: 1,
     }
     ctMock.project('dummy').add('customer', customer)
@@ -35,5 +37,74 @@ describe('Customer Update Actions', () => {
     expect(response.status).toBe(200)
     expect(response.body.version).toBe(2)
     expect(response.body.email).toBe('new@example.com')
+  })
+
+  test('setAuthenticationMode to an invalid mode', async () => {
+    assert(customer, 'customer not created')
+
+    const response = await supertest(ctMock.app)
+      .post(`/dummy/customers/${customer.id}`)
+      .send({
+        version: 1,
+        actions: [{ action: 'setAuthenticationMode', authMode: 'invalid' }],
+      })
+    expect(response.status).toBe(400)
+    expect(response.body.message).toBe('Request body does not contain valid JSON.')
+    expect(response.body.errors[0].code).toBe('InvalidJsonInput')
+    expect(response.body.errors[0].detailedErrorMessage).toBe("actions -> authMode: Invalid enum value: 'invalid'. Expected one of: 'Password','ExternalAuth'")
+  })
+
+
+  test('setAuthenticationMode to ExternalAuth', async () => {
+    assert(customer, 'customer not created')
+
+    const response = await supertest(ctMock.app)
+      .post(`/dummy/customers/${customer.id}`)
+      .send({
+        version: 1,
+        actions: [{ action: 'setAuthenticationMode', authMode: 'ExternalAuth' }],
+      })
+    expect(response.status).toBe(200)
+    expect(response.body.version).toBe(2)
+    expect(response.body.authenticationMode).toBe('ExternalAuth')
+    expect(response.body.password).toBe(undefined)
+  })
+
+  test('setAuthenticationMode error when setting current authMode', async () => {
+    assert(customer, 'customer not created')
+    assert(customer.authenticationMode == "Password", 'customer not in default state')
+
+    const response = await supertest(ctMock.app)
+      .post(`/dummy/customers/${customer.id}`)
+      .send({
+        version: 1,
+        actions: [{ action: 'setAuthenticationMode', authMode: 'Password', password: "newpass" }],
+      })
+    expect(response.status).toBe(400)
+    expect(response.body.message).toBe("The customer is already using the 'Password' authentication mode.")
+  })
+
+  test('setAuthenticationMode to Password', async () => {
+    assert(customer, 'customer not created')
+
+    //change *away from* Password authMode (to be able to test changing *to* Password authMode)
+    await supertest(ctMock.app)
+      .post(`/dummy/customers/${customer.id}`)
+      .send({
+        version: 1,
+        actions: [{ action: 'setAuthenticationMode', authMode: 'ExternalAuth' }],
+      })
+
+    //change to Password authMode
+    const response = await supertest(ctMock.app)
+      .post(`/dummy/customers/${customer.id}`)
+      .send({
+        version: 2,
+        actions: [{ action: 'setAuthenticationMode', authMode: 'Password', password: "newpass" }],
+      })
+    expect(response.status).toBe(200)
+    expect(response.body.version).toBe(3)
+    expect(response.body.authenticationMode).toBe('Password')
+    expect(response.body.password).toBe(Buffer.from('newpass').toString('base64'))
   })
 })

--- a/src/services/customer.test.ts
+++ b/src/services/customer.test.ts
@@ -1,0 +1,39 @@
+import assert from 'assert'
+import { Customer } from '@commercetools/platform-sdk'
+import supertest from 'supertest'
+import { CommercetoolsMock, getBaseResourceProperties } from '../index'
+
+describe('Customer Update Actions', () => {
+  const ctMock = new CommercetoolsMock()
+  let customer: Customer | undefined
+
+  beforeEach(async () => {
+    customer = {
+      ...getBaseResourceProperties(),
+      id: 'customer-uuid',
+      email: 'user@example.com',
+      addresses: [],
+      isEmailVerified: true,
+      version: 1,
+    }
+    ctMock.project('dummy').add('customer', customer)
+  })
+
+  afterEach(() => {
+    ctMock.clear()
+  })
+
+  test('changeEmail', async () => {
+    assert(customer, 'customer not created')
+
+    const response = await supertest(ctMock.app)
+      .post(`/dummy/customers/${customer.id}`)
+      .send({
+        version: 1,
+        actions: [{ action: 'changeEmail', email: 'new@example.com' }],
+      })
+    expect(response.status).toBe(200)
+    expect(response.body.version).toBe(2)
+    expect(response.body.email).toBe('new@example.com')
+  })
+})


### PR DESCRIPTION
This PR adds the `setAuthenticationMode` update action to the Customer resource. It is used for switching a customer to use External Authentication.

The change is test-covered for the cases I could imagine and which I tested against a real Commercetools project.

This PR also adds a test for the existing `changeEmail` update action.