### PR TITLE
chore/add update actions

### DIFF
--- a/src/repositories/standalone-price.ts
+++ b/src/repositories/standalone-price.ts
@@ -1,11 +1,13 @@
 import {
-  Review,
   StandalonePrice,
-  StandalonePriceUpdateAction,
+  StandalonePriceChangeActiveAction,
+  StandalonePriceChangeValueAction,
+  StandalonePriceSetDiscountedPriceAction,
 } from '@commercetools/platform-sdk'
 import { getBaseResourceProperties } from '../helpers'
 import { Writable } from '../types'
 import { AbstractResourceRepository, RepositoryContext } from './abstract'
+import { createTypedMoney } from './helpers'
 
 export class StandAlonePriceRepository extends AbstractResourceRepository<'standalone-price'> {
   getTypeId() {
@@ -17,20 +19,42 @@ export class StandAlonePriceRepository extends AbstractResourceRepository<'stand
       ...getBaseResourceProperties(),
       active: draft.active,
       sku: draft.sku,
-      value: draft.value,
+      value: createTypedMoney(draft.value),
+      country: draft.country,
+      channel: draft.channel,
     }
     this.saveNew(context, resource)
     return resource
   }
 
-  actions: Partial<
-    Record<
-      StandalonePriceUpdateAction['action'],
-      (
-        context: RepositoryContext,
-        resource: Writable<Review>,
-        action: any
-      ) => void
-    >
-  > = {}
+  actions = {
+    setActive: (
+      context: RepositoryContext,
+      resource: Writable<StandalonePrice>,
+      action: StandalonePriceChangeActiveAction
+    ) => {
+      resource.active = action.active
+    },
+    changeValue: (
+      context: RepositoryContext,
+      resource: Writable<StandalonePrice>,
+      action: StandalonePriceChangeValueAction
+    ) => {
+      resource.value = createTypedMoney(action.value)
+    },
+    setDiscountedPrice: ( 
+      context: RepositoryContext,
+      resource: Writable<StandalonePrice>,
+      action: StandalonePriceSetDiscountedPriceAction
+    ) => {
+      if (action.discounted) {
+        resource.discounted = {
+          value: createTypedMoney(action.discounted.value),
+          discount: action.discounted.discount,
+        }
+      } else {
+        resource.discounted = undefined
+      }
+    }
+  }
 }

--- a/src/services/standalone-price.test.ts
+++ b/src/services/standalone-price.test.ts
@@ -4,65 +4,272 @@ import { CommercetoolsMock } from '../index'
 
 const ctMock = new CommercetoolsMock()
 
-describe('StandalonePrice', () => {
-    test('Create standalone price', async () => {
+describe('Standalone price Query', () => {
+    beforeAll(async () => {
         const draft: StandalonePriceDraft = {
-            sku: 'test-sku',
             value: {
+                centAmount: 100,
                 currencyCode: 'EUR',
-                centAmount: 1000,
             },
+            country: 'DE',
+            sku: 'foo',
             active: true,
+            channel: {
+                typeId: 'channel',
+                id: 'bar',
+            },
+            discounted: {
+                value: {
+                    centAmount: 80,
+                    currencyCode: 'EUR',
+                },
+                discount: {
+                    typeId: 'product-discount',
+                    id: 'baz',
+                },
+            },
         }
+        const createResponse = await supertest(ctMock.app)
+            .post('/dummy/standalone-prices')
+            .send(draft)
+        expect(createResponse.status).toEqual(201)
+    })
 
-        const response = await supertest(ctMock.app).post('/dummy/standalone-prices').send(draft)
-        expect(response.status).toBe(201)
+    afterAll(async () => {
+        ctMock.clear()
     })
 
     test('Get standalone price', async () => {
-        const draft: StandalonePriceDraft = {
-            sku: 'test-sku',
-            value: {
-                currencyCode: 'EUR',
-                centAmount: 1000,
-            },
-            active: true,
-        }
+        const response = await supertest(ctMock.app).get('/dummy/standalone-prices?sku=foo')
 
-        const createResponse = await supertest(ctMock.app).post('/dummy/standalone-prices').send(draft)
-
-        const response = await supertest(ctMock.app).get(`/dummy/standalone-prices/${createResponse.body.id}`)
         expect(response.status).toBe(200)
+
+        expect(response.body.results).toEqual([
+            {
+                active: true,
+                channel: {
+                    id: 'bar',
+                    typeId: 'channel',
+                },
+                country: 'DE',
+                createdAt: expect.anything(),
+                discounted: {
+                    discount: {
+                        id: 'baz',
+                        typeId: 'product-discount',
+                    },
+                    value: {
+                        centAmount: 80,
+                        currencyCode: 'EUR',
+                        fractionDigits: 2,
+                        type: 'centPrecision',
+                    },
+                },
+                id: expect.anything(),
+                lastModifiedAt: expect.anything(),
+                sku: 'foo',
+                value: {
+                    centAmount: 100,
+                    currencyCode: 'EUR',
+                    fractionDigits: 2,
+                    type: 'centPrecision',
+                },
+                version: 1,
+            },
+        ])
+    })
+})
+
+describe('Standalone price Actions', () => {
+    let id: string | undefined
+    beforeEach(async () => {
+        const draft: StandalonePriceDraft = {
+            value: {
+                centAmount: 100,
+                currencyCode: 'EUR',
+            },
+            country: 'DE',
+            sku: 'foo',
+            active: true,
+            channel: {
+                typeId: 'channel',
+                id: 'bar',
+            },
+        }
+        const createResponse = await supertest(ctMock.app)
+            .post('/dummy/standalone-prices')
+            .send(draft)
+        expect(createResponse.status).toEqual(201)
+        id = createResponse.body.id
     })
 
-    test('Update standalone price', async () => {
-        const draft: StandalonePriceDraft = {
-            sku: 'test-sku',
-            value: {
-                currencyCode: 'EUR',
-                centAmount: 1000,
-            },
-            active: true,
-        }
+    afterEach(async () => {
+        ctMock.clear()
+    })
 
-        const createResponse = await supertest(ctMock.app).post('/dummy/standalone-prices').send(draft)
-
+    test('changeValue', async () => {
         const response = await supertest(ctMock.app)
-            .post(`/dummy/standalone-prices/${createResponse.body.id}`)
+            .post('/dummy/standalone-prices/' + id)
             .send({
-                version: createResponse.body.version,
+                version: 1,
                 actions: [
                     {
                         action: 'changeValue',
                         value: {
+                            centAmount: 200,
                             currencyCode: 'EUR',
-                            centAmount: 2000,
                         },
                     },
                 ],
             })
+
         expect(response.status).toBe(200)
-        expect(response.body.id).toBe(createResponse.body.id)
-        expect(response.body.value.centAmount).toBe(2000)
+
+        expect(response.body).toEqual({
+            active: true,
+            channel: {
+                id: 'bar',
+                typeId: 'channel',
+            },
+            country: 'DE',
+            createdAt: expect.anything(),
+            id: id,
+            lastModifiedAt: expect.anything(),
+            sku: 'foo',
+            value: {
+                centAmount: 200,
+                currencyCode: 'EUR',
+                fractionDigits: 2,
+                type: 'centPrecision',
+            },
+            version: 2,
+        })
+    })
+
+    test('setActive', async () => {
+        const response = await supertest(ctMock.app)
+            .post('/dummy/standalone-prices/' + id)
+            .send({
+                version: 1,
+                actions: [
+                    {
+                        action: 'setActive',
+                        active: false,
+                    },
+                ],
+            })
+
+        expect(response.status).toBe(200)
+
+        expect(response.body).toEqual({
+            active: false,
+            channel: {
+                id: 'bar',
+                typeId: 'channel',
+            },
+            country: 'DE',
+            createdAt: expect.anything(),
+            id: id,
+            lastModifiedAt: expect.anything(),
+            sku: 'foo',
+            value: {
+                centAmount: 100,
+                currencyCode: 'EUR',
+                fractionDigits: 2,
+                type: 'centPrecision',
+            },
+            version: 2,
+        })
+    })
+
+    test('setDiscounted', async () => {
+        const response = await supertest(ctMock.app)
+            .post('/dummy/standalone-prices/' + id)
+            .send({
+                version: 1,
+                actions: [
+                    {
+                        action: 'setDiscountedPrice',
+                        discounted: {
+                            value: {
+                                centAmount: 80,
+                                currencyCode: 'EUR',
+                            },
+                            discount: {
+                                typeId: 'product-discount',
+                                id: 'baz',
+                            },
+                        },
+                    },
+                ],
+            })
+
+        expect(response.status).toBe(200)
+
+        expect(response.body).toEqual({
+            active: true,
+            channel: {
+                id: 'bar',
+                typeId: 'channel',
+            },
+            country: 'DE',
+            createdAt: expect.anything(),
+            discounted: {
+                discount: {
+                    id: 'baz',
+                    typeId: 'product-discount',
+                },
+                value: {
+                    centAmount: 80,
+                    currencyCode: 'EUR',
+                    fractionDigits: 2,
+                    type: 'centPrecision',
+                },
+            },
+            id: id,
+            lastModifiedAt: expect.anything(),
+            sku: 'foo',
+            value: {
+                centAmount: 100,
+                currencyCode: 'EUR',
+                fractionDigits: 2,
+                type: 'centPrecision',
+            },
+            version: 2,
+        })
+
+        const response2 = await supertest(ctMock.app)
+            .post('/dummy/standalone-prices/' + id)
+            .send({
+                version: 2,
+                actions: [
+                    {
+                        action: 'setDiscountedPrice',
+                        discounted: null,
+                    },
+                ],
+            })
+
+        expect(response2.status).toBe(200)
+
+        expect(response2.body).toEqual({
+            active: true,
+            channel: {
+                id: 'bar',
+                typeId: 'channel',
+            },
+            country: 'DE',
+            createdAt: expect.anything(),
+            id: id,
+            lastModifiedAt: expect.anything(),
+            sku: 'foo',
+            value: {
+                centAmount: 100,
+                currencyCode: 'EUR',
+                fractionDigits: 2,
+                type: 'centPrecision',
+            },
+            version: 3,
+        })
     })
 })

--- a/src/services/standalone-price.test.ts
+++ b/src/services/standalone-price.test.ts
@@ -34,4 +34,35 @@ describe('StandalonePrice', () => {
         const response = await supertest(ctMock.app).get(`/dummy/standalone-prices/${createResponse.body.id}`)
         expect(response.status).toBe(200)
     })
+
+    test('Update standalone price', async () => {
+        const draft: StandalonePriceDraft = {
+            sku: 'test-sku',
+            value: {
+                currencyCode: 'EUR',
+                centAmount: 1000,
+            },
+            active: true,
+        }
+
+        const createResponse = await supertest(ctMock.app).post('/dummy/standalone-prices').send(draft)
+
+        const response = await supertest(ctMock.app)
+            .post(`/dummy/standalone-prices/${createResponse.body.id}`)
+            .send({
+                version: createResponse.body.version,
+                actions: [
+                    {
+                        action: 'changeValue',
+                        value: {
+                            currencyCode: 'EUR',
+                            centAmount: 2000,
+                        },
+                    },
+                ],
+            })
+        expect(response.status).toBe(200)
+        expect(response.body.id).toBe(createResponse.body.id)
+        expect(response.body.value.centAmount).toBe(2000)
+    })
 })


### PR DESCRIPTION
This PR supports adding additional fields such as `country`, `channel`, `discount`, `validFrom`, and `validUntil` for the standalone price. The implementation also provides support for update actions and is covered with unit tests.