### PR TITLE
Fix the product projection query endpoint

### DIFF
--- a/.changeset/red-keys-melt.md
+++ b/.changeset/red-keys-melt.md
@@ -1,0 +1,5 @@
+---
+'@labdigital/commercetools-mock': minor
+---
+
+Fix implementation of the product projection query endpoint. This also fixes some issues with passing condition values as separate values (var.name)

--- a/src/lib/predicateParser.ts
+++ b/src/lib/predicateParser.ts
@@ -32,11 +32,11 @@ export const matchesPredicate = (
 	if (Array.isArray(predicate)) {
 		return predicate.every((item) => {
 			const func = generateMatchFunc(item)
-			return func(target, variables || {})
+			return func(target, variables ?? {})
 		})
 	} else {
 		const func = generateMatchFunc(predicate)
-		return func(target, variables || {})
+		return func(target, variables ?? {})
 	}
 }
 
@@ -76,7 +76,7 @@ const validateSymbol = (val: TypeSymbol) => {
 
 const resolveSymbol = (val: TypeSymbol, vars: VariableMap): any => {
 	if (val.type === 'var') {
-		if (!(val.value in vars)) {
+		if (!(val.value in (vars ?? {}))) {
 			throw new PredicateError(`Missing parameter value for ${val.value}`)
 		}
 		return vars[val.value]
@@ -245,7 +245,7 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 			return (obj: any, vars: object) => {
 				const value = resolveValue(obj, left)
 				if (value) {
-					return expr(value)
+					return expr(value, vars)
 				}
 				return false
 			}

--- a/src/repositories/product-projection.ts
+++ b/src/repositories/product-projection.ts
@@ -1,16 +1,33 @@
 import type {
+	InvalidInputError,
 	ProductDraft,
 	ProductProjection,
+	QueryParam,
 } from '@commercetools/platform-sdk'
 import { ParsedQs } from 'qs'
 import { QueryParamsAsArray } from '../helpers.js'
 import { ProductProjectionSearch } from '../product-projection-search.js'
 import { type AbstractStorage } from '../storage/index.js'
-import {
-	AbstractResourceRepository,
-	type QueryParams,
-	RepositoryContext,
-} from './abstract.js'
+import { AbstractResourceRepository, RepositoryContext } from './abstract.js'
+import { parseQueryExpression } from '../lib/predicateParser.js'
+import { CommercetoolsError } from '../exceptions.js'
+
+type ProductProjectionQueryParams = {
+	staged?: boolean
+	priceCurrency?: string
+	priceCountry?: string
+	priceCustomerGroup?: string
+	priceChannel?: string
+	localeProjection?: string | string[]
+	storeProjection?: string
+	expand?: string | string[]
+	sort?: string | string[]
+	limit?: number
+	offset?: number
+	withTotal?: boolean
+	where?: string | string[]
+	[key: string]: QueryParam
+}
 
 export class ProductProjectionRepository extends AbstractResourceRepository<'product-projection'> {
 	protected _searchService: ProductProjectionSearch
@@ -28,19 +45,63 @@ export class ProductProjectionRepository extends AbstractResourceRepository<'pro
 		throw new Error('No valid action')
 	}
 
-	query(context: RepositoryContext, params: QueryParams = {}) {
-		const response = this._storage.query(context.projectKey, 'product', {
-			expand: params.expand,
-			where: params.where,
-			offset: params.offset,
-			limit: params.limit,
-		})
+	query(context: RepositoryContext, params: ProductProjectionQueryParams = {}) {
+		let resources = this._storage
+			.all(context.projectKey, 'product')
+			.map((r) => this._searchService.transform(r, params.staged ?? false))
+			.filter((p) => {
+				if (!params.staged ?? false) {
+					return p.published
+				}
+				return true
+			})
+
+		// Apply predicates
+		if (params.where) {
+			const variableMap: Record<string, QueryParam> = {}
+			for (const [k, v] of Object.entries(params)) {
+				if (k.startsWith('var.')) {
+					variableMap[k.substring(4)] = v
+				}
+			}
+
+			try {
+				const filterFunc = parseQueryExpression(params.where)
+				resources = resources.filter((resource) =>
+					filterFunc(resource, variableMap)
+				)
+			} catch (err) {
+				throw new CommercetoolsError<InvalidInputError>(
+					{
+						code: 'InvalidInput',
+						message: (err as any).message,
+					},
+					400
+				)
+			}
+		}
+
+		// Expand the resources
+		if (params.expand !== undefined) {
+			resources = resources.map((resource) =>
+				this._storage.expand(context.projectKey, resource, params.expand)
+			)
+		}
+
+		// Create a slice for the pagination. If we were working with large datasets
+		// then we should have done this before transforming. But that isn't the
+		// goal of this library. So lets keep it simple.
+		const totalResults = resources.length
+		const offset = params.offset || 0
+		const limit = params.limit || 20
+		const results = resources.slice(offset, offset + limit)
 
 		return {
-			...response,
-			results: response.results.map((r) =>
-				this._searchService.transform(r, false)
-			),
+			count: totalResults,
+			total: results.length,
+			offset: offset,
+			limit: limit,
+			results: results,
 		}
 	}
 

--- a/src/services/abstract.ts
+++ b/src/services/abstract.ts
@@ -167,7 +167,7 @@ export default abstract class AbstractService {
 	}
 
 	// No idea what i'm doing
-	private _parseParam(
+	protected _parseParam(
 		value: string | ParsedQs | string[] | ParsedQs[] | undefined
 	): string[] | undefined {
 		if (Array.isArray(value)) {

--- a/src/services/product-projection.test.ts
+++ b/src/services/product-projection.test.ts
@@ -201,6 +201,70 @@ afterEach(async () => {
 })
 
 // Test the general product projection implementation
+describe('Product Projection Query - Generic', () => {
+	test('Filter out staged', async () => {
+		{
+			const response = await supertest(ctMock.app)
+				.get('/dummy/product-projections')
+				.query({
+					limit: 50,
+				})
+
+			const result: ProductProjectionPagedSearchResponse = response.body
+			expect(result).toEqual({
+				count: 1,
+				limit: 50,
+				offset: 0,
+				total: 1,
+				results: [productProjection],
+			})
+		}
+	})
+
+	test('Filter on valid slug', async () => {
+		{
+			const response = await supertest(ctMock.app)
+				.get('/dummy/product-projections')
+				.query({
+					limit: 50,
+					where: ['slug(nl-NL=:slug)'],
+					'var.slug': 'test-product',
+				})
+
+			const result: ProductProjectionPagedSearchResponse = response.body
+			expect(result).toEqual({
+				count: 1,
+				limit: 50,
+				offset: 0,
+				total: 1,
+				results: [productProjection],
+			})
+		}
+	})
+
+	test('Filter on invalid slug', async () => {
+		{
+			const response = await supertest(ctMock.app)
+				.get('/dummy/product-projections')
+				.query({
+					limit: 50,
+					where: ['slug(nl-NL=:slug)'],
+					'var.slug': 'missing-product',
+				})
+
+			const result: ProductProjectionPagedSearchResponse = response.body
+			expect(result).toEqual({
+				count: 0,
+				limit: 50,
+				offset: 0,
+				total: 0,
+				results: [],
+			})
+		}
+	})
+})
+
+// Test the general product projection implementation
 describe('Product Projection Search - Generic', () => {
 	test('Pagination', async () => {
 		{

--- a/src/services/product-projection.ts
+++ b/src/services/product-projection.ts
@@ -19,6 +19,20 @@ export class ProductProjectionService extends AbstractService {
 		router.get('/search', this.search.bind(this))
 	}
 
+	get(request: Request, response: Response) {
+		const limit = this._parseParam(request.query.limit)
+		const offset = this._parseParam(request.query.offset)
+
+		const result = this.repository.query(getRepositoryContext(request), {
+			...request.query,
+			expand: this._parseParam(request.query.expand),
+			where: this._parseParam(request.query.where),
+			limit: limit !== undefined ? Number(limit) : undefined,
+			offset: offset !== undefined ? Number(offset) : undefined,
+		})
+		return response.status(200).send(result)
+	}
+
 	search(request: Request, response: Response) {
 		const resource = this.repository.search(
 			getRepositoryContext(request),


### PR DESCRIPTION
This didn’t work at all previously. This implementation should make the
staged/non-staged work correctly and should include proper filtering.

Specific storeProjection or localeProjections are not supported yet
