### PR TITLE
Feature/Extend product resource support

### DIFF
--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -20,6 +20,7 @@ import type {
 	ProductRemovePriceAction,
 	CategoryReference,
 	TaxCategoryReference,
+	StateReference,
 } from '@commercetools/platform-sdk'
 import { v4 as uuidv4 } from 'uuid'
 import type { Writable } from '../types.js'
@@ -59,7 +60,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 			}
 		}
 
-		// Product categories
+		// Resolve Product categories
 		const categoryReferences: CategoryReference[] = []
 		draft.categories?.forEach((category) => {
 			try {
@@ -70,11 +71,11 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 					)
 				)
 			} catch (err) {
-				throw new Error(`Cannot resolve category: ${JSON.stringify(category)}`)
+				throw new Error(err)
 			}
 		})
 
-		// Tax category
+		// Resolve Tax category
 		let taxCategoryReference: TaxCategoryReference | undefined = undefined
 		if(draft.taxCategory) {
 			try {
@@ -84,7 +85,21 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 					this._storage
 				)
 			} catch(err) {
-				throw new Error(`Cannot resolve tax category: ${JSON.stringify(draft.taxCategory)}`)
+				throw new Error(err)
+			}
+		}
+
+		// Resolve Product State
+		let productStateReference: StateReference | undefined = undefined
+		if(draft.state) {
+			try {
+				productStateReference = getReferenceFromResourceIdentifier<StateReference>(
+					draft.state,
+					context.projectKey,
+					this._storage
+				)
+			} catch(err) {
+				throw new Error(err)
 			}
 		}
 
@@ -109,6 +124,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 			key: draft.key,
 			productType: productType,
 			taxCategory: taxCategoryReference,
+			state: productStateReference,
 			masterData: {
 				current: productData,
 				staged: productData,

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -18,6 +18,7 @@ import type {
 	ProductChangePriceAction,
 	ProductAddPriceAction,
 	ProductRemovePriceAction,
+	CategoryReference,
 } from '@commercetools/platform-sdk'
 import { v4 as uuidv4 } from 'uuid'
 import type { Writable } from '../types.js'
@@ -57,10 +58,25 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 			}
 		}
 
+		// Product categories
+		const categoryReferences: CategoryReference[] = []
+		draft.categories?.forEach((category) => {
+			try {
+				categoryReferences.push(getReferenceFromResourceIdentifier<CategoryReference>(
+						category,
+						context.projectKey,
+						this._storage
+					)
+				)
+			} catch (err) {
+				throw new Error(`Cannot resolve category: ${JSON.stringify(category)}`)
+			}
+		})
+
 		const productData: ProductData = {
 			name: draft.name,
 			slug: draft.slug,
-			categories: [],
+			categories: categoryReferences,
 			masterVariant: variantFromDraft(1, draft.masterVariant),
 			variants:
 				draft.variants?.map((variant, index) =>

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -99,6 +99,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 					variantFromDraft(index + 2, variant)
 				) ?? [],
 			metaTitle: draft.metaTitle,
+			metaDescription: draft.metaDescription,
 			searchKeywords: draft.searchKeywords ?? {},
 		}
 

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -100,6 +100,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 				) ?? [],
 			metaTitle: draft.metaTitle,
 			metaDescription: draft.metaDescription,
+			metaKeywords: draft.metaKeywords,
 			searchKeywords: draft.searchKeywords ?? {},
 		}
 

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -19,6 +19,7 @@ import type {
 	ProductAddPriceAction,
 	ProductRemovePriceAction,
 	CategoryReference,
+	TaxCategoryReference,
 } from '@commercetools/platform-sdk'
 import { v4 as uuidv4 } from 'uuid'
 import type { Writable } from '../types.js'
@@ -73,6 +74,20 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 			}
 		})
 
+		// Tax category
+		let taxCategoryReference: TaxCategoryReference | undefined = undefined
+		if(draft.taxCategory) {
+			try {
+				taxCategoryReference = getReferenceFromResourceIdentifier<TaxCategoryReference>(
+					draft.taxCategory,
+					context.projectKey,
+					this._storage
+				)
+			} catch(err) {
+				throw new Error(`Cannot resolve tax category: ${JSON.stringify(draft.taxCategory)}`)
+			}
+		}
+
 		const productData: ProductData = {
 			name: draft.name,
 			slug: draft.slug,
@@ -91,6 +106,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 			...getBaseResourceProperties(),
 			key: draft.key,
 			productType: productType,
+			taxCategory: taxCategoryReference,
 			masterData: {
 				current: productData,
 				staged: productData,

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -76,6 +76,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 		const productData: ProductData = {
 			name: draft.name,
 			slug: draft.slug,
+			description: draft.description,
 			categories: categoryReferences,
 			masterVariant: variantFromDraft(1, draft.masterVariant),
 			variants:

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -64,7 +64,8 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 		const categoryReferences: CategoryReference[] = []
 		draft.categories?.forEach((category) => {
 			try {
-				categoryReferences.push(getReferenceFromResourceIdentifier<CategoryReference>(
+				categoryReferences.push(
+					getReferenceFromResourceIdentifier<CategoryReference>(
 						category,
 						context.projectKey,
 						this._storage
@@ -77,28 +78,30 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 
 		// Resolve Tax category
 		let taxCategoryReference: TaxCategoryReference | undefined = undefined
-		if(draft.taxCategory) {
+		if (draft.taxCategory) {
 			try {
-				taxCategoryReference = getReferenceFromResourceIdentifier<TaxCategoryReference>(
-					draft.taxCategory,
-					context.projectKey,
-					this._storage
-				)
-			} catch(err) {
+				taxCategoryReference =
+					getReferenceFromResourceIdentifier<TaxCategoryReference>(
+						draft.taxCategory,
+						context.projectKey,
+						this._storage
+					)
+			} catch (err) {
 				throw new Error(err)
 			}
 		}
 
 		// Resolve Product State
 		let productStateReference: StateReference | undefined = undefined
-		if(draft.state) {
+		if (draft.state) {
 			try {
-				productStateReference = getReferenceFromResourceIdentifier<StateReference>(
-					draft.state,
-					context.projectKey,
-					this._storage
-				)
-			} catch(err) {
+				productStateReference =
+					getReferenceFromResourceIdentifier<StateReference>(
+						draft.state,
+						context.projectKey,
+						this._storage
+					)
+			} catch (err) {
 				throw new Error(err)
 			}
 		}

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -676,6 +676,7 @@ const variantFromDraft = (
 
 const priceFromDraft = (draft: PriceDraft): Price => ({
 	id: uuidv4(),
+	key: draft.key,
 	country: draft.country,
 	value: createTypedMoney(draft.value),
 })

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -87,7 +87,9 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 						this._storage
 					)
 			} catch (err) {
-				throw new Error(`Error resolving tax category with key '${draft.taxCategory}'.`)
+				throw new Error(
+					`Error resolving tax category with key '${draft.taxCategory}'.`
+				)
 			}
 		}
 

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -651,6 +651,7 @@ const variantFromDraft = (
 ): ProductVariant => ({
 	id: variantId,
 	sku: variant?.sku,
+	key: variant?.key,
 	attributes: variant?.attributes ?? [],
 	prices: variant?.prices?.map(priceFromDraft),
 	assets: [],

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -98,7 +98,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 				draft.variants?.map((variant, index) =>
 					variantFromDraft(index + 2, variant)
 				) ?? [],
-
+			metaTitle: draft.metaTitle,
 			searchKeywords: draft.searchKeywords ?? {},
 		}
 

--- a/src/repositories/product.ts
+++ b/src/repositories/product.ts
@@ -72,7 +72,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 					)
 				)
 			} catch (err) {
-				throw new Error(err)
+				throw new Error(`Error resolving category '${category}'.`)
 			}
 		})
 
@@ -87,7 +87,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 						this._storage
 					)
 			} catch (err) {
-				throw new Error(err)
+				throw new Error(`Error resolving tax category with key '${draft.taxCategory}'.`)
 			}
 		}
 
@@ -102,7 +102,7 @@ export class ProductRepository extends AbstractResourceRepository<'product'> {
 						this._storage
 					)
 			} catch (err) {
-				throw new Error(err)
+				throw new Error(`Error resolving state '${draft.state}'.`)
 			}
 		}
 

--- a/src/services/product.test.ts
+++ b/src/services/product.test.ts
@@ -21,22 +21,22 @@ import { CommercetoolsMock } from '../index.js'
 const productTypeDraft: ProductTypeDraft = {
 	key: 'test-product-type',
 	name: 'Test Product Type',
-	description: 'Test Product Type description'
+	description: 'Test Product Type description',
 }
 
 const categoryDraft: CategoryDraft = {
 	key: 'category-1',
 	name: {
-		'nl-NL': 'Category One'
+		'nl-NL': 'Category One',
 	},
 	slug: {
-		'nl-NL': 'category_1'
-	}
+		'nl-NL': 'category_1',
+	},
 }
 
 const taxcategoryDraft: TaxCategoryDraft = {
 	name: 'Tax category 1',
-	key: 'tax-category-1'
+	key: 'tax-category-1',
 }
 
 const productStateDraft: StateDraft = {
@@ -48,7 +48,7 @@ const productStateDraft: StateDraft = {
 	},
 	description: {
 		'nl-NL': 'Product initial state',
-	}
+	},
 }
 
 const publishedProductDraft: ProductDraft = {
@@ -56,7 +56,7 @@ const publishedProductDraft: ProductDraft = {
 		'nl-NL': 'test published product',
 	},
 	description: {
-		'nl-NL': 'Test published product description'
+		'nl-NL': 'Test published product description',
 	},
 	productType: {
 		typeId: 'product-type',
@@ -66,7 +66,7 @@ const publishedProductDraft: ProductDraft = {
 		{
 			typeId: 'category',
 			key: 'category-1',
-		}
+		},
 	],
 	taxCategory: {
 		typeId: 'tax-category',
@@ -139,7 +139,7 @@ const unpublishedProductDraft: ProductDraft = {
 		'nl-NL': 'test unpublished product',
 	},
 	description: {
-		'nl-NL': 'Test published product description'
+		'nl-NL': 'Test published product description',
 	},
 	productType: {
 		typeId: 'product-type',
@@ -149,10 +149,10 @@ const unpublishedProductDraft: ProductDraft = {
 		{
 			typeId: 'category',
 			key: 'category-1',
-		}
+		},
 	],
 	taxCategory: {
-		typeId: "tax-category",
+		typeId: 'tax-category',
 		key: taxcategoryDraft.key,
 	},
 	state: {
@@ -251,7 +251,7 @@ async function beforeAllProductTests(mock) {
 	response = await supertest(mock.app)
 		.post('/dummy/states')
 		.send(productStateDraft)
-	
+
 	expect(response.status).toBe(201)
 	productState = response.body
 }
@@ -274,15 +274,17 @@ describe('Product', () => {
 				'nl-NL': 'test unpublished product',
 			},
 			description: {
-				'nl-NL': 'Test published product description'
+				'nl-NL': 'Test published product description',
 			},
 			slug: {
 				'nl-NL': 'test-unpublished-product',
 			},
-			categories: [{
-				'id': category.id,
-				'typeId': 'category',
-			}],
+			categories: [
+				{
+					id: category.id,
+					typeId: 'category',
+				},
+			],
 			metaTitle: {
 				'nl-NL': 'Unpublished product (meta title)',
 			},


### PR DESCRIPTION
Added additional fields to be supported by the Product resource, such as:
- Categories
- Description
- Tax category
- Meta Title
- Meta Description
- Meta Keywords
- Product Variant Key
- Product State
- Product Variant's Price Key
- Updated test to cover new fields