### PR TITLE
feat: add cart recalculate action

### DIFF
--- a/.changeset/sixty-turtles-happen.md
+++ b/.changeset/sixty-turtles-happen.md
@@ -1,0 +1,5 @@
+---
+'@labdigital/commercetools-mock': minor
+---
+
+add support for cart recalculate action

--- a/src/repositories/cart.ts
+++ b/src/repositories/cart.ts
@@ -7,6 +7,7 @@ import {
 	type CartAddItemShippingAddressAction,
 	type CartSetLineItemShippingDetailsAction,
 	type CartDraft,
+	type CartRecalculateAction,
 	type CartRemoveLineItemAction,
 	type CartSetBillingAddressAction,
 	type CartSetCountryAction,
@@ -229,6 +230,15 @@ export class CartRepository extends AbstractResourceRepository<'cart'> {
 
 			// Update cart total price
 			resource.totalPrice.centAmount = calculateCartTotalPrice(resource)
+		},
+		recalculate: () => {
+			// Dummy action when triggering a recalculation of the cart
+			//
+			// From commercetools documentation:
+			// This update action does not set any Cart field in particular,
+			// but it triggers several Cart updates to bring prices and discounts to the latest state.
+			// Those can become stale over time when no Cart updates have been performed for a while
+			// and prices on related Products have changed in the meanwhile.
 		},
 		addItemShippingAddress: (
 			context: RepositoryContext,

--- a/src/repositories/cart.ts
+++ b/src/repositories/cart.ts
@@ -7,7 +7,6 @@ import {
 	type CartAddItemShippingAddressAction,
 	type CartSetLineItemShippingDetailsAction,
 	type CartDraft,
-	type CartRecalculateAction,
 	type CartRemoveLineItemAction,
 	type CartSetBillingAddressAction,
 	type CartSetCountryAction,

--- a/src/services/cart.test.ts
+++ b/src/services/cart.test.ts
@@ -318,7 +318,7 @@ describe('Cart Update Actions', () => {
 				actions: [
 					{
 						action: 'recalculate',
-						updateProductData: true
+						updateProductData: true,
 					},
 				],
 			})

--- a/src/services/cart.test.ts
+++ b/src/services/cart.test.ts
@@ -303,6 +303,30 @@ describe('Cart Update Actions', () => {
 		expect(response.body.lineItems).toHaveLength(0)
 	})
 
+	test('recalculate', async () => {
+		const product = await supertest(ctMock.app)
+			.post(`/dummy/products`)
+			.send(productDraft)
+			.then((x) => x.body)
+
+		assert(cart, 'cart not created')
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/carts/${cart.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{
+						action: 'recalculate',
+						updateProductData: true
+					},
+				],
+			})
+
+		expect(response.status).toBe(200)
+		expect(response.body.version).toBe(1)
+	})
+
 	test('removeLineItem', async () => {
 		const product = await supertest(ctMock.app)
 			.post(`/dummy/products`)


### PR DESCRIPTION
# Add cart recalculate action

The cart recalculate action is missing in this package, and will raise an error now because of this. I just implemented a dummy action to fix its not raising an error anymore. And I think it's fine, because commercetools does some things under the hood when calling this action. (see my code comment about this)