### PR TITLE
fix: predicate parser correctly match objects in array

### DIFF
--- a/.changeset/nasty-knives-camp.md
+++ b/.changeset/nasty-knives-camp.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+fixes matching of queries for array objects in predicate parser

--- a/src/lib/predicateParser.test.ts
+++ b/src/lib/predicateParser.test.ts
@@ -127,6 +127,7 @@ describe("Predicate filter", () => {
 		expect(match(`numberProperty >= 1234`)).toBeTruthy();
 		expect(match(`numberProperty >= 1235`)).toBeFalsy();
 	});
+
 	test("numberProperty < ...", async () => {
 		expect(match(`numberProperty < 1235`)).toBeTruthy();
 		expect(match(`numberProperty < 1234`)).toBeFalsy();
@@ -180,6 +181,16 @@ describe("Predicate filter", () => {
 		expect(match(`nested(array(stringProperty="bar"))`)).toBeTruthy();
 		expect(match(`nested(array(stringProperty="foobar"))`)).toBeFalsy();
 
+		// Different comparison operators
+		expect(match(`nested(array(numberProperty>=2345))`)).toBeTruthy();
+		expect(match(`nested(array(numberProperty>=2346))`)).toBeFalsy();
+		expect(match(`nested(array(numberProperty>2344))`)).toBeTruthy();
+		expect(match(`nested(array(numberProperty>2345))`)).toBeFalsy();
+		expect(match(`nested(array(numberProperty<=1234))`)).toBeTruthy();
+		expect(match(`nested(array(numberProperty<=1233))`)).toBeFalsy();
+		expect(match(`nested(array(numberProperty<1235))`)).toBeTruthy();
+		expect(match(`nested(array(numberProperty<1234))`)).toBeFalsy();
+
 		// One level deeper
 		expect(
 			match(`nested(array(objectProperty(stringProperty="foo")))`),
@@ -189,6 +200,35 @@ describe("Predicate filter", () => {
 		).toBeTruthy();
 		expect(
 			match(`nested(array(objectProperty(stringProperty="foobar")))`),
+		).toBeFalsy();
+	});
+
+	test("nested array multiple filters on property", async () => {
+		expect(
+			match(
+				`nested(array(stringProperty="foo" and numberProperty=2345 and objectProperty(stringProperty="foo")))`,
+			),
+		).toBeFalsy();
+		expect(
+			match(`nested(array(stringProperty="foo" or numberProperty=2345))`),
+		).toBeTruthy();
+		expect(
+			match(
+				`nested(array(stringProperty="foo" and numberProperty > 1233 and numberProperty < 1235))`,
+			),
+		).toBeTruthy();
+		expect(
+			match(
+				`nested(array(stringProperty="foo" and numberProperty >= 1234 and numberProperty <= 1234))`,
+			),
+		).toBeTruthy();
+		expect(
+			match(`nested(array(stringProperty="foo" and numberProperty != 1233))`),
+		).toBeTruthy();
+		expect(
+			match(
+				`nested(array(stringProperty="foobar" and numberProperty > 1234 and numberProperty < 1237))`,
+			),
 		).toBeFalsy();
 	});
 

--- a/src/lib/predicateParser.ts
+++ b/src/lib/predicateParser.ts
@@ -259,6 +259,10 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 				} else {
 					const value = resolveValue(obj, left);
 					if (value) {
+						if (Array.isArray(value)) {
+							return value.some((item) => expr(item, vars));
+						}
+
 						return expr(value, vars);
 					}
 					return false;
@@ -469,8 +473,8 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 
 		throw new PredicateError(
 			`Unexpected end of input, expected SphereIdentifierChar, comparison ` +
-				`operator, not, in, contains, is, within or matches` +
-				` (line ${lines.length}, column ${column})`,
+			`operator, not, in, contains, is, within or matches` +
+			` (line ${lines.length}, column ${column})`,
 		);
 	}
 	return result;


### PR DESCRIPTION
Small fix to generating of a matching function in the predicate parser. When trying to match an object in an array with multiple conditions it would try to match the conditions individually for all objects in the array. While it should try to match all the conditions for at least 1 item in the array.

Example:
Query: `array(stringProperty="foo" and numberProperty=2345)` would have matched if the array contained an object with `stringProperty="foo"` and one object with: `numberProperty=2345`. Instead of matching only if the array contained an object with both `stringProperty="foo" and numberProperty=2345`.