### PR TITLE
fix: custom-objects with container results

### DIFF
--- a/.changeset/lucky-chairs-arrive.md
+++ b/.changeset/lucky-chairs-arrive.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Fix customObject withContainer postProcessResource arguments

--- a/src/repositories/custom-object.ts
+++ b/src/repositories/custom-object.ts
@@ -93,7 +93,11 @@ export class CustomObjectRepository extends AbstractResourceRepository<"key-valu
 		});
 
 		// @ts-ignore
-		result.results = result.results.map(this.postProcessResource);
+		result.results = result.results.map((r) =>
+			this.postProcessResource(context, r as CustomObject, {
+				expand: params.expand,
+			}),
+		);
 		return result;
 	}
 }

--- a/src/services/custom-object.test.ts
+++ b/src/services/custom-object.test.ts
@@ -75,6 +75,25 @@ describe("CustomObject retrieve", () => {
 		expect(customObject.value).toBe("my-value");
 	});
 
+	test("query with container", async () => {
+		const response = await supertest(ctMock.app)
+			.get("/dummy/custom-objects/my-container")
+			.send();
+
+		expect(response.status).toBe(200);
+		const customObjects = response.body;
+		expect(customObjects).toMatchObject({
+			results: [
+				{
+					container: "my-container",
+					key: "my-key",
+					value: "my-value",
+				},
+			],
+			total: 1,
+		});
+	});
+
 	test("Update match current (no conflict)", async () => {
 		const response = await supertest(ctMock.app)
 			.post("/dummy/custom-objects")


### PR DESCRIPTION
The arguments for the `postProcessResource` has been changed in the following commit:
https://github.com/labd/commercetools-node-mock/commit/08e651b5d60554b5bd40862b134ece0b11833a91#diff-b5c53b0ebb282ab7281fc320a01f5eabd1699676f6606c175ac72a42260f6bed

Therefore we also need to update this postProcessResource-call for custom objects.