### PR TITLE
Add change shipment state action in order action

### DIFF
--- a/.changeset/twelve-schools-join.md
+++ b/.changeset/twelve-schools-join.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Added missing test OrderChangeShipmentStateAction in order action

--- a/src/repositories/order/actions.ts
+++ b/src/repositories/order/actions.ts
@@ -6,6 +6,7 @@ import type {
 	OrderAddReturnInfoAction,
 	OrderChangeOrderStateAction,
 	OrderChangePaymentStateAction,
+	OrderChangeShipmentStateAction,
 	OrderSetBillingAddressAction,
 	OrderSetCustomFieldAction,
 	OrderSetCustomTypeAction,
@@ -19,7 +20,6 @@ import type {
 	OrderTransitionStateAction,
 	OrderUpdateAction,
 	OrderUpdateSyncInfoAction,
-	OrderChangeShipmentStateAction,
 	ReturnInfo,
 	State,
 	Store,
@@ -121,9 +121,9 @@ export class OrderUpdateHandler
 	changeShipmentState(
 		context: RepositoryContext,
 		resource: Writable<Order>,
-		{ shipmentState }: OrderChangeShipmentStateAction
+		{ shipmentState }: OrderChangeShipmentStateAction,
 	) {
-		resource.shipmentState = shipmentState
+		resource.shipmentState = shipmentState;
 	}
 
 	setBillingAddress(

--- a/src/repositories/order/actions.ts
+++ b/src/repositories/order/actions.ts
@@ -19,6 +19,7 @@ import type {
 	OrderTransitionStateAction,
 	OrderUpdateAction,
 	OrderUpdateSyncInfoAction,
+	OrderChangeShipmentStateAction,
 	ReturnInfo,
 	State,
 	Store,
@@ -115,6 +116,14 @@ export class OrderUpdateHandler
 		{ paymentState }: OrderChangePaymentStateAction,
 	) {
 		resource.paymentState = paymentState;
+	}
+
+	changeShipmentState(
+		context: RepositoryContext,
+		resource: Writable<Order>,
+		{ shipmentState }: OrderChangeShipmentStateAction
+	) {
+		resource.shipmentState = shipmentState
 	}
 
 	setBillingAddress(

--- a/src/services/order.test.ts
+++ b/src/services/order.test.ts
@@ -403,6 +403,22 @@ describe("Order Update Actions", () => {
 		expect(response.body.paymentState).toBe("Failed");
 	});
 
+	test("changeShipmentState", async () => {
+		assert(order, "order not created");
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/orders/${order.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{ action: "changeShipmentState", shipmentState: "Delayed" },
+				],
+			});
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(2);
+		expect(response.body.shipmentState).toBe("Delayed");
+	});
+
 	test("setDeliveryCustomField", async () => {
 		const order: Order = {
 			...getBaseResourceProperties(),

--- a/src/services/order.test.ts
+++ b/src/services/order.test.ts
@@ -410,9 +410,7 @@ describe("Order Update Actions", () => {
 			.post(`/dummy/orders/${order.id}`)
 			.send({
 				version: 1,
-				actions: [
-					{ action: "changeShipmentState", shipmentState: "Delayed" },
-				],
+				actions: [{ action: "changeShipmentState", shipmentState: "Delayed" }],
 			});
 		expect(response.status).toBe(200);
 		expect(response.body.version).toBe(2);


### PR DESCRIPTION
This changes add `changePaymentState` in the order action to handle setting of shipmentState property, which is missing for the test for our project.