### PR TITLE
fix: allow addedAt override in add to wishlist and add to cart 

### DIFF
--- a/.changeset/wet-poems-appear.md
+++ b/.changeset/wet-poems-appear.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+allows addedAt override in add to cart and add to wishlist

--- a/src/repositories/cart/actions.ts
+++ b/src/repositories/cart/actions.ts
@@ -73,7 +73,14 @@ export class CartUpdateHandler
 	addLineItem(
 		context: RepositoryContext,
 		resource: Writable<Cart>,
-		{ productId, variantId, sku, custom, quantity = 1 }: CartAddLineItemAction,
+		{
+			productId,
+			variantId,
+			sku,
+			custom,
+			quantity = 1,
+			addedAt,
+		}: CartAddLineItemAction,
 	) {
 		let product: Product | null = null;
 
@@ -157,6 +164,7 @@ export class CartUpdateHandler
 			}
 			resource.lineItems.push({
 				id: uuidv4(),
+				addedAt: addedAt ? addedAt : new Date().toISOString(),
 				productId: product.id,
 				productKey: product.key,
 				productSlug: product.masterData.current.slug,

--- a/src/repositories/shopping-list/actions.ts
+++ b/src/repositories/shopping-list/actions.ts
@@ -36,7 +36,13 @@ export class ShoppingListUpdateHandler
 	addLineItem(
 		context: RepositoryContext,
 		resource: Writable<ShoppingList>,
-		{ productId, variantId, sku, quantity = 1 }: ShoppingListAddLineItemAction,
+		{
+			productId,
+			variantId,
+			sku,
+			quantity = 1,
+			addedAt,
+		}: ShoppingListAddLineItemAction,
 	) {
 		let product: Product | null = null;
 
@@ -90,7 +96,7 @@ export class ShoppingListUpdateHandler
 		} else {
 			// add line item
 			resource.lineItems.push({
-				addedAt: new Date().toISOString(),
+				addedAt: addedAt ? addedAt : new Date().toISOString(),
 				id: uuidv4(),
 				productId: product.id,
 				productSlug: product.masterData.current.slug,


### PR DESCRIPTION
Sets default of addedAt in cart,
Allows override to be passed in cart
Allows override to be passed in wishlist

This is important as we order line items on the addedAt value, when we exchange a line item, we pass the addedAt value to preserve the order and need to test this