### PR TITLE
feat(order): add support for setPurchaseOrderNumber order update action

### DIFF
--- a/.changeset/green-brooms-cover.md
+++ b/.changeset/green-brooms-cover.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+add support for "setPurchaseOrderNumber" order update action

--- a/src/repositories/order/actions.ts
+++ b/src/repositories/order/actions.ts
@@ -15,6 +15,7 @@ import type {
 	OrderSetDeliveryCustomFieldAction,
 	OrderSetLocaleAction,
 	OrderSetOrderNumberAction,
+	OrderSetPurchaseOrderNumberAction,
 	OrderSetShippingAddressAction,
 	OrderSetStoreAction,
 	OrderTransitionStateAction,
@@ -225,6 +226,14 @@ export class OrderUpdateHandler
 		{ orderNumber }: OrderSetOrderNumberAction,
 	) {
 		resource.orderNumber = orderNumber;
+	}
+
+	setPurchaseOrderNumber(
+		context: RepositoryContext,
+		resource: Writable<Order>,
+		{ purchaseOrderNumber }: OrderSetPurchaseOrderNumberAction,
+	) {
+		resource.purchaseOrderNumber = purchaseOrderNumber;
 	}
 
 	setShippingAddress(

--- a/src/services/order.test.ts
+++ b/src/services/order.test.ts
@@ -371,6 +371,22 @@ describe("Order Update Actions", () => {
 		expect(response.body.orderNumber).toBe("5000123");
 	});
 
+	test("setPurchaseOrderNumber", async () => {
+		assert(order, "order not created");
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/orders/${order.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{ action: "setPurchaseOrderNumber", purchaseOrderNumber: "abc123" },
+				],
+			});
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(2);
+		expect(response.body.purchaseOrderNumber).toBe("abc123");
+	});
+
 	test("changeOrderState", async () => {
 		assert(order, "order not created");
 


### PR DESCRIPTION
Add support for `setPurchaseOrderNumber` order update action.