### PR TITLE
Feat: address custom type actions

### DIFF
--- a/.changeset/afraid-donuts-change.md
+++ b/.changeset/afraid-donuts-change.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Added the setShippingAddressCustomType and setBillingAddressCustomType actions to the cart repository

--- a/src/repositories/cart/actions.ts
+++ b/src/repositories/cart/actions.ts
@@ -12,6 +12,7 @@ import {
 	type CartRemoveDiscountCodeAction,
 	type CartRemoveLineItemAction,
 	type CartSetBillingAddressAction,
+	type CartSetBillingAddressCustomTypeAction,
 	type CartSetCountryAction,
 	type CartSetCustomFieldAction,
 	type CartSetCustomShippingMethodAction,
@@ -21,6 +22,7 @@ import {
 	type CartSetLineItemShippingDetailsAction,
 	type CartSetLocaleAction,
 	type CartSetShippingAddressAction,
+	type CartSetShippingAddressCustomTypeAction,
 	type CartSetShippingMethodAction,
 	type CustomFields,
 	type GeneralError,
@@ -323,6 +325,38 @@ export class CartUpdateHandler
 		);
 	}
 
+	setBillingAddressCustomType(
+		context: RepositoryContext,
+		resource: Writable<Cart>,
+		custom: CartSetBillingAddressCustomTypeAction,
+	) {
+		if (!resource.billingAddress) {
+			throw new Error("Resource has no billing address");
+		}
+
+		if (!custom.type) {
+			resource.billingAddress.custom = undefined;
+			return;
+		}
+
+		const resolvedType = this._storage.getByResourceIdentifier<"type">(
+			context.projectKey,
+			custom.type,
+		);
+
+		if (!resolvedType) {
+			throw new Error(`Type ${custom.type} not found`);
+		}
+
+		resource.billingAddress.custom = {
+			type: {
+				typeId: "type",
+				id: resolvedType.id,
+			},
+			fields: custom.fields || {},
+		};
+	}
+
 	setCountry(
 		context: RepositoryContext,
 		resource: Writable<Cart>,
@@ -500,6 +534,38 @@ export class CartUpdateHandler
 		resource.shippingAddress = {
 			...address,
 			custom: custom,
+		};
+	}
+
+	setShippingAddressCustomType(
+		context: RepositoryContext,
+		resource: Writable<Cart>,
+		custom: CartSetShippingAddressCustomTypeAction,
+	) {
+		if (!resource.shippingAddress) {
+			throw new Error("Resource has no shipping address");
+		}
+
+		if (!custom.type) {
+			resource.shippingAddress.custom = undefined;
+			return;
+		}
+
+		const resolvedType = this._storage.getByResourceIdentifier<"type">(
+			context.projectKey,
+			custom.type,
+		);
+
+		if (!resolvedType) {
+			throw new Error(`Type ${custom.type} not found`);
+		}
+
+		resource.shippingAddress.custom = {
+			type: {
+				typeId: "type",
+				id: resolvedType.id,
+			},
+			fields: custom.fields || {},
 		};
 	}
 

--- a/src/services/cart.test.ts
+++ b/src/services/cart.test.ts
@@ -605,6 +605,140 @@ describe("Cart Update Actions", () => {
 		expect(response.body.shippingAddress).toEqual(address);
 	});
 
+	test("setBillingAddressCustomType", async () => {
+		assert(cart, "cart not created");
+
+		const address: Address = {
+			streetName: "Street name",
+			city: "Utrecht",
+			country: "NL",
+		};
+
+		const type = await supertest(ctMock.app)
+			.post(`/dummy/types`)
+			.send({
+				key: "my-type",
+				name: {
+					en: "My Type",
+				},
+				description: {
+					en: "My Type Description",
+				},
+				fieldDefinitions: [
+					{
+						name: "foo",
+						label: {
+							en: "foo",
+						},
+						required: false,
+						type: {
+							name: "String",
+						},
+						inputHint: "SingleLine",
+					},
+				],
+			})
+			.then((x) => x.body);
+
+		assert(type, "type not created");
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/carts/${cart.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{ action: "setBillingAddress", address },
+					{
+						action: "setBillingAddressCustomType",
+						type: {
+							typeId: "type",
+							type: "my-type",
+							key: "my-type",
+						},
+						fields: {
+							foo: "bar",
+						},
+					},
+				],
+			});
+
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(3);
+		expect(response.body.billingAddress).toEqual({
+			...address,
+			custom: {
+				type: { typeId: "type", id: type.id },
+				fields: { foo: "bar" },
+			},
+		});
+	});
+	test("setShippingAddressCustomType", async () => {
+		assert(cart, "cart not created");
+
+		const address: Address = {
+			streetName: "Street name",
+			city: "Utrecht",
+			country: "NL",
+		};
+
+		const type = await supertest(ctMock.app)
+			.post(`/dummy/types`)
+			.send({
+				key: "my-type",
+				name: {
+					en: "My Type",
+				},
+				description: {
+					en: "My Type Description",
+				},
+				fieldDefinitions: [
+					{
+						name: "foo",
+						label: {
+							en: "foo",
+						},
+						required: false,
+						type: {
+							name: "String",
+						},
+						inputHint: "SingleLine",
+					},
+				],
+			})
+			.then((x) => x.body);
+
+		assert(type, "type not created");
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/carts/${cart.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{ action: "setShippingAddress", address },
+					{
+						action: "setShippingAddressCustomType",
+						type: {
+							typeId: "type",
+							type: "my-type",
+							key: "my-type",
+						},
+						fields: {
+							foo: "bar",
+						},
+					},
+				],
+			});
+
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(3);
+		expect(response.body.shippingAddress).toEqual({
+			...address,
+			custom: {
+				type: { typeId: "type", id: type.id },
+				fields: { foo: "bar" },
+			},
+		});
+	});
 	test("setLineItemShippingDetails", async () => {
 		const product = await supertest(ctMock.app)
 			.post(`/dummy/products`)


### PR DESCRIPTION
Added the setShippingAddressCustomType and setBillingAddressCustomType actions to the cart repository
