### PR TITLE
feat: set addresses on customer create

### DIFF
--- a/.changeset/weak-scissors-jam.md
+++ b/.changeset/weak-scissors-jam.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add ability to set shipping and billing addresses when creating customer

--- a/src/services/my-customer.test.ts
+++ b/src/services/my-customer.test.ts
@@ -35,6 +35,8 @@ describe("Me", () => {
 				version: 1,
 				isEmailVerified: false,
 				addresses: [],
+				billingAddressIds: [],
+				shippingAddressIds: [],
 				id: expect.anything(),
 				createdAt: expect.anything(),
 				lastModifiedAt: expect.anything(),


### PR DESCRIPTION
Add ability to set shipping and billing addresses when creating customer
via the `shippingAddresses` and `billingAddresses`
