### PR TITLE
Improve mocking of customer updates.

### DIFF
--- a/.changeset/gorgeous-turtles-judge.md
+++ b/.changeset/gorgeous-turtles-judge.md
@@ -1,0 +1,8 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Improve mocking of customer updates. This includes adding support for
+`removeAddress`, `removeBillingAddressId`, `removeShippingAddressId`,
+`setCustomerGroup`, `setDateOfBirth`, `setDefaultShippingAddress`,
+`setDefaultBillingAddress`, `setMiddleName`, `setTitle`.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"eslint": "^8.57.0",
 		"eslint-plugin-sort-class-members": "^1.20.0",
 		"eslint-plugin-unused-imports": "^3.1.0",
+		"fishery": "^2.2.2",
 		"got": "^14.2.0",
 		"husky": "^9.0.11",
 		"prettier": "^3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^3.1.0
         version: 3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)
+      fishery:
+        specifier: ^2.2.2
+        version: 2.2.2
       got:
         specifier: ^14.2.0
         version: 14.4.2
@@ -1707,6 +1710,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  fishery@2.2.2:
+    resolution: {integrity: sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==}
+
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2134,6 +2140,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -4807,6 +4816,10 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  fishery@2.2.2:
+    dependencies:
+      lodash.mergewith: 4.6.2
+
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.1
@@ -5219,6 +5232,8 @@ snapshots:
   lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
 

--- a/src/repositories/abstract.ts
+++ b/src/repositories/abstract.ts
@@ -1,5 +1,6 @@
 import type {
 	BaseResource,
+	InvalidInputError,
 	Project,
 	QueryParam,
 	ResourceNotFoundError,
@@ -253,6 +254,22 @@ export class AbstractUpdateHandler {
 			: (resource as Project).key;
 
 		for (const action of actions) {
+			// Validate if this action exists
+			// @ts-ignore
+			if (this[action.action] === undefined) {
+				console.info(`No handler for action ${action.action}`);
+				throw new CommercetoolsError<InvalidInputError>({
+					code: "InvalidInput",
+					message: `Invalid action ${action.action}`,
+					errors: [
+						{
+							code: "InvalidInput",
+							message: `Invalid action ${action.action}`,
+						},
+					],
+				});
+			}
+
 			// @ts-ignore
 			const updateFunc = this[action.action].bind(this);
 


### PR DESCRIPTION
This includes adding support for:
 - `removeAddress`,
 - `removeBillingAddressId`
 - `removeShippingAddressId`
 - `setCustomerGroup`
 - `setDateOfBirth`
 - `setDefaultShippingAddress`
 - `setDefaultBillingAddress`
 - `setMiddleName`
 - `setTitle`

This change also improves the testing of some actions and introduces
`fishery` as dependency to ease the test creation
