### PR TITLE
Deprecate ctMock.add()

### DIFF
--- a/.changeset/silent-scissors-remain.md
+++ b/.changeset/silent-scissors-remain.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add deprecation warning for `ctMock.add()`

--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -5,22 +5,20 @@ import morgan from "morgan";
 import { http, HttpResponse } from "msw";
 import type { SetupServer, SetupServerApi } from "msw/node";
 import { setupServer } from "msw/node";
+import type { Config } from "./config";
 import { DEFAULT_API_HOSTNAME, DEFAULT_AUTH_HOSTNAME } from "./constants";
 import { CommercetoolsError } from "./exceptions";
+import { mapHeaderType } from "./helpers";
 import { copyHeaders } from "./lib/proxy";
 import { OAuth2Server } from "./oauth/server";
 import { ProjectAPI } from "./projectAPI";
-import type { AbstractStorage } from "./storage";
-import { InMemoryStorage } from "./storage";
-
-// Services
-import type { Config } from "./config";
-import { mapHeaderType } from "./helpers";
 import type { RepositoryMap } from "./repositories";
 import { createRepositories } from "./repositories";
 import type { ProjectRepository } from "./repositories/project";
 import { createServices } from "./services";
 import { ProjectService } from "./services/project";
+import type { AbstractStorage } from "./storage";
+import { InMemoryStorage } from "./storage";
 
 export type CommercetoolsMockOptions = {
 	validateCredentials: boolean;
@@ -77,7 +75,8 @@ export class CommercetoolsMock {
 
 	start() {
 		process.emitWarning(
-			"The start method is deprecated, use .registerHandlers() to bind to an msw server instead",
+			"The start() method is deprecated, use .registerHandlers() to bind to an msw server instead",
+			"DeprecationWarning",
 		);
 
 		// Order is important here when the hostnames match
@@ -87,7 +86,8 @@ export class CommercetoolsMock {
 
 	stop() {
 		process.emitWarning(
-			"The stop method is deprecated, use .registerHandlers() to bind to an msw server instead",
+			"The stop() method is deprecated, use .registerHandlers() to bind to an msw server instead",
+			"DeprecationWarning",
 		);
 		this._mswServer?.close();
 		this._mswServer = undefined;

--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -106,10 +106,15 @@ export class CommercetoolsMock {
 			throw new Error("repositories not initialized yet");
 		}
 
+		const config: Config = {
+			strict: this.options.strict,
+			storage: this._storage,
+		};
+
 		return new ProjectAPI(
 			projectKey || this.options.defaultProjectKey!,
 			this._repositories,
-			this._storage,
+			config,
 		);
 	}
 

--- a/src/projectAPI.ts
+++ b/src/projectAPI.ts
@@ -25,6 +25,18 @@ export class ProjectAPI {
 		typeId: T,
 		resource: ResourceMap[T],
 	) {
+		process.emitWarning(
+			"ctMock.add() is deprecated, create resources via regular create endpoints " +
+				"or if you are really sure, use unsafeAdd() (but be aware of potential state issues)",
+			"DeprecationWarning",
+		);
+		this.unsafeAdd(typeId, resource);
+	}
+
+	unsafeAdd<T extends keyof RepositoryMap & keyof ResourceMap>(
+		typeId: T,
+		resource: ResourceMap[T],
+	) {
 		const repository = this._repositories[typeId];
 		if (repository) {
 			this._storage.add(this.projectKey, typeId, {

--- a/src/projectAPI.ts
+++ b/src/projectAPI.ts
@@ -1,3 +1,4 @@
+import type { Config } from "./config";
 import { getBaseResourceProperties } from "./helpers";
 import type { RepositoryMap } from "./repositories";
 import type { GetParams } from "./repositories/abstract";
@@ -11,13 +12,12 @@ export class ProjectAPI {
 
 	private _repositories: RepositoryMap;
 
-	constructor(
-		projectKey: string,
-		repositories: RepositoryMap,
-		storage: AbstractStorage,
-	) {
+	private config: Config;
+
+	constructor(projectKey: string, repositories: RepositoryMap, config: Config) {
 		this.projectKey = projectKey;
-		this._storage = storage;
+		this.config = config;
+		this._storage = config.storage;
 		this._repositories = repositories;
 	}
 


### PR DESCRIPTION
The `ctMock.add()` function directly inserts objects in the in-memory store of commercetools mock, which could result in invalid objects being processed due to missing validation, or pre processing hooks.

This change introduces a new method `unsafeAdd()` to still have this option available while clearly signalling you shouldn't normally use it. 

Note that this for now only shows a deprecation warning, the functionality will still be there for the foreseeable future
