### PR TITLE
fix(customer): add setting of stores on customer

### DIFF
--- a/.changeset/curly-carpets-learn.md
+++ b/.changeset/curly-carpets-learn.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add support for setting stores on customers

--- a/src/repositories/customer/index.test.ts
+++ b/src/repositories/customer/index.test.ts
@@ -1,12 +1,11 @@
+import type { Store } from "@commercetools/platform-sdk";
 import { describe, expect, test } from "vitest";
 import { InMemoryStorage } from "~src/storage";
 import { CustomerRepository } from "./index";
-import { Store } from "@commercetools/platform-sdk";
 
 describe("Order repository", () => {
 	const storage = new InMemoryStorage();
 	const repository = new CustomerRepository(storage);
-
 
 	test("adding stores to customer", async () => {
 		const store1: Store = {
@@ -48,14 +47,16 @@ describe("Order repository", () => {
 			{ projectKey: "dummy" },
 			{
 				email: "my-customer@email.com",
-				stores: [{
-					typeId: "store",
-					id: store1.id
-				},
-				{
-					typeId: "store",
-					key: store2.key
-				}]
+				stores: [
+					{
+						typeId: "store",
+						id: store1.id,
+					},
+					{
+						typeId: "store",
+						key: store2.key,
+					},
+				],
 			},
 		);
 
@@ -63,11 +64,11 @@ describe("Order repository", () => {
 		expect(result?.stores).toEqual([
 			{
 				typeId: "store",
-				key: store1.key
+				key: store1.key,
 			},
 			{
 				typeId: "store",
-				key: store2.key
+				key: store2.key,
 			},
 		]);
 	});

--- a/src/repositories/customer/index.test.ts
+++ b/src/repositories/customer/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { InMemoryStorage } from "~src/storage";
+import { CustomerRepository } from "./index";
+import { Store } from "@commercetools/platform-sdk";
+
+describe("Order repository", () => {
+	const storage = new InMemoryStorage();
+	const repository = new CustomerRepository(storage);
+
+
+	test("adding stores to customer", async () => {
+		const store1: Store = {
+			id: "d0016081-e9af-48a7-8133-1f04f340a335",
+			key: "store-1",
+			name: {
+				en: "Store 1",
+			},
+			version: 1,
+			createdAt: "2021-09-02T12:23:30.036Z",
+			lastModifiedAt: "2021-09-02T12:23:30.546Z",
+			languages: [],
+			distributionChannels: [],
+			countries: [],
+			supplyChannels: [],
+			productSelections: [],
+		};
+
+		const store2: Store = {
+			id: "6dac7d6d-2a48-4705-aa8b-17b0124a499a",
+			key: "store-2",
+			name: {
+				en: "Store 2",
+			},
+			version: 1,
+			createdAt: "2021-09-02T12:23:30.036Z",
+			lastModifiedAt: "2021-09-02T12:23:30.546Z",
+			languages: [],
+			distributionChannels: [],
+			countries: [],
+			supplyChannels: [],
+			productSelections: [],
+		};
+
+		storage.add("dummy", "store", store1);
+		storage.add("dummy", "store", store2);
+
+		const result = repository.create(
+			{ projectKey: "dummy" },
+			{
+				email: "my-customer@email.com",
+				stores: [{
+					typeId: "store",
+					id: store1.id
+				},
+				{
+					typeId: "store",
+					key: store2.key
+				}]
+			},
+		);
+
+		expect(result?.stores).toHaveLength(2);
+		expect(result?.stores).toEqual([
+			{
+				typeId: "store",
+				key: store1.key
+			},
+			{
+				typeId: "store",
+				key: store2.key
+			},
+		]);
+	});
+});

--- a/src/repositories/customer/index.ts
+++ b/src/repositories/customer/index.ts
@@ -103,18 +103,16 @@ export class CustomerRepository extends AbstractResourceRepository<"customer"> {
 				lookupAdressId(addresses, addressId),
 			) ?? [];
 
-		let storesForCustomer: StoreKeyReference[] = []
+		let storesForCustomer: StoreKeyReference[] = [];
 
 		if (draft.stores) {
-			const storeIds = draft.stores.map((storeReference) => storeReference.id).filter(Boolean);
+			const storeIds = draft.stores
+				.map((storeReference) => storeReference.id)
+				.filter(Boolean);
 
-			const stores = this._storage.query(
-				context.projectKey,
-				"store",
-				{
-					where: storeIds.map((id) => `id="${id}"`),
-				},
-			).results;
+			const stores = this._storage.query(context.projectKey, "store", {
+				where: storeIds.map((id) => `id="${id}"`),
+			}).results;
 
 			if (storeIds.length !== stores.length) {
 				throw new CommercetoolsError<ResourceNotFoundError>({
@@ -125,7 +123,10 @@ export class CustomerRepository extends AbstractResourceRepository<"customer"> {
 
 			storesForCustomer = draft.stores.map((storeReference) => ({
 				typeId: "store",
-				key: storeReference.key ?? stores.find((store) => store.id === storeReference.id)?.key as string,
+				key:
+					storeReference.key ??
+					(stores.find((store) => store.id === storeReference.id)
+						?.key as string),
 			}));
 		}
 


### PR DESCRIPTION
Passing store references when creating a customer currently doesn't associate the customer to the store. This adds that functionality

**Changes:**
- Set store references on the customer resource
- Map any storeId references to storeKey references (since only storeKey reference are saved on the customer)