### PR TITLE
fix(customer): customer repository allow no stores

### DIFF
--- a/.changeset/cold-bugs-approve.md
+++ b/.changeset/cold-bugs-approve.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Fix customer not being allowed to have no stores

--- a/src/repositories/customer/index.test.ts
+++ b/src/repositories/customer/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { InMemoryStorage } from "~src/storage";
 import { CustomerRepository } from "./index";
 
-describe("Order repository", () => {
+describe("Customer repository", () => {
 	const storage = new InMemoryStorage();
 	const repository = new CustomerRepository(storage);
 
@@ -71,5 +71,18 @@ describe("Order repository", () => {
 				key: store2.key,
 			},
 		]);
+	});
+
+	test("adding customer without linked stores", async () => {
+		const result = repository.create(
+			{ projectKey: "dummy" },
+			{
+				email: "my-customer-without-stores@email.com",
+				stores: [],
+			},
+		);
+
+		expect(result.email).toEqual("my-customer-without-stores@email.com");
+		expect(result?.stores).toHaveLength(0);
 	});
 });

--- a/src/repositories/customer/index.ts
+++ b/src/repositories/customer/index.ts
@@ -105,7 +105,7 @@ export class CustomerRepository extends AbstractResourceRepository<"customer"> {
 
 		let storesForCustomer: StoreKeyReference[] = [];
 
-		if (draft.stores) {
+		if (draft.stores && draft.stores.length > 0) {
 			const storeIds = draft.stores
 				.map((storeReference) => storeReference.id)
 				.filter(Boolean);


### PR DESCRIPTION
Empty arrays for the stores of a customer were wrongfully check for empty arrays. Fixes issue introduced in #249.