### PR TITLE
fix: set empty array for associates when creating a business unit

### DIFF
--- a/.changeset/lovely-rabbits-hear.md
+++ b/.changeset/lovely-rabbits-hear.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Allow setting associates to business unit, if its created without associates

--- a/src/repositories/business-unit.ts
+++ b/src/repositories/business-unit.ts
@@ -91,9 +91,10 @@ export class BusinessUnitRepository extends AbstractResourceRepository<"business
 			associateMode: draft.associateMode,
 			approvalRuleMode: draft.approvalRuleMode,
 
-			associates: draft.associates?.map((a) =>
-				createAssociate(a, context.projectKey, this._storage),
-			) ?? [],
+			associates:
+				draft.associates?.map((a) =>
+					createAssociate(a, context.projectKey, this._storage),
+				) ?? [],
 		};
 
 		if (this._isDivisionDraft(draft)) {
@@ -130,7 +131,8 @@ export class BusinessUnitRepository extends AbstractResourceRepository<"business
 class BusinessUnitUpdateHandler
 	extends AbstractUpdateHandler
 	implements
-	Partial<UpdateHandlerInterface<BusinessUnit, BusinessUnitUpdateAction>> {
+		Partial<UpdateHandlerInterface<BusinessUnit, BusinessUnitUpdateAction>>
+{
 	addAddress(
 		context: RepositoryContext,
 		resource: Writable<BusinessUnit>,

--- a/src/repositories/business-unit.ts
+++ b/src/repositories/business-unit.ts
@@ -93,7 +93,7 @@ export class BusinessUnitRepository extends AbstractResourceRepository<"business
 
 			associates: draft.associates?.map((a) =>
 				createAssociate(a, context.projectKey, this._storage),
-			),
+			) ?? [],
 		};
 
 		if (this._isDivisionDraft(draft)) {
@@ -130,8 +130,7 @@ export class BusinessUnitRepository extends AbstractResourceRepository<"business
 class BusinessUnitUpdateHandler
 	extends AbstractUpdateHandler
 	implements
-		Partial<UpdateHandlerInterface<BusinessUnit, BusinessUnitUpdateAction>>
-{
+	Partial<UpdateHandlerInterface<BusinessUnit, BusinessUnitUpdateAction>> {
 	addAddress(
 		context: RepositoryContext,
 		resource: Writable<BusinessUnit>,


### PR DESCRIPTION
Adding associates fails, if associates value is not set to empty array when creating the business unit.