### PR TITLE
feat: Add `ctMock().getHandlers()`

### DIFF
--- a/.changeset/young-bats-boil.md
+++ b/.changeset/young-bats-boil.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Add `ctMock().getHandlers()` to return all msw handlers for initial setup

--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -197,8 +197,13 @@ export class CommercetoolsMock {
 	// allows you to manage msw server yourself and register the handlers needed
 	// for commercetools-mock to work.
 	public registerHandlers(server: SetupServerApi) {
+		const handlers = this.getHandlers(server);
+		server.use(...handlers);
+	}
+
+	public getHandlers(server: SetupServerApi) {
 		const app = this.app;
-		server.use(
+		return [
 			http.post(`${this.options.authHost}/oauth/*`, async ({ request }) => {
 				const body = await request.text();
 				const url = new URL(request.url);
@@ -290,7 +295,7 @@ export class CommercetoolsMock {
 					headers: mapHeaderType(res.headers),
 				});
 			}),
-		);
+		];
 	}
 
 	public mswServer() {


### PR DESCRIPTION
This allows us to use the handlers for one-time setup:

e.g.
```
const mswServer = setupServer(...ctMock.getHandlers());
```
