### PR TITLE
feat: add key support to addLineItem

### DIFF
--- a/.changeset/neat-cougars-bake.md
+++ b/.changeset/neat-cougars-bake.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add support for key field in addLineItem actions

--- a/src/repositories/cart/actions.ts
+++ b/src/repositories/cart/actions.ts
@@ -92,6 +92,7 @@ export class CartUpdateHandler
 			custom,
 			quantity = 1,
 			addedAt,
+			key,
 		}: CartAddLineItemAction,
 	) {
 		let product: Product | null = null;
@@ -176,6 +177,7 @@ export class CartUpdateHandler
 			}
 			resource.lineItems.push({
 				id: uuidv4(),
+				key,
 				addedAt: addedAt ? addedAt : new Date().toISOString(),
 				productId: product.id,
 				productKey: product.key,

--- a/src/repositories/shopping-list/actions.ts
+++ b/src/repositories/shopping-list/actions.ts
@@ -39,6 +39,7 @@ export class ShoppingListUpdateHandler
 			sku,
 			quantity = 1,
 			addedAt,
+			key,
 		}: ShoppingListAddLineItemAction,
 	) {
 		let product: Product | null = null;
@@ -95,6 +96,7 @@ export class ShoppingListUpdateHandler
 			resource.lineItems.push({
 				addedAt: addedAt ? addedAt : new Date().toISOString(),
 				id: uuidv4(),
+				key,
 				productId: product.id,
 				productSlug: product.masterData.current.slug,
 				productType: product.productType,

--- a/src/services/cart.test.ts
+++ b/src/services/cart.test.ts
@@ -361,6 +361,66 @@ describe("Cart Update Actions", () => {
 		});
 	});
 
+	test("addLineItem with key", async () => {
+		const product = await supertest(ctMock.app)
+			.post(`/dummy/products`)
+			.send(productDraft)
+			.then((x) => x.body);
+
+		const type = await supertest(ctMock.app)
+			.post(`/dummy/types`)
+			.send({
+				key: "my-type",
+				name: {
+					en: "My Type",
+				},
+				description: {
+					en: "My Type Description",
+				},
+				fieldDefinitions: [
+					{
+						name: "foo",
+						label: {
+							en: "foo",
+						},
+						required: false,
+						type: {
+							name: "String",
+						},
+						inputHint: "SingleLine",
+					},
+				],
+			})
+			.then((x) => x.body);
+
+		assert(type, "type not created");
+		assert(cart, "cart not created");
+		assert(product, "product not created");
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/carts/${cart.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{
+						action: "addLineItem",
+						sku: "1337",
+						key: "my-key",
+						quantity: 2,
+						custom: {
+							type: { typeId: "type", key: "my-type" },
+							fields: { foo: "bar" },
+						},
+					},
+				],
+			});
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(2);
+		expect(response.body.lineItems).toHaveLength(1);
+		expect(response.body.lineItems[0].key).toBeDefined();
+		expect(response.body.lineItems[0].key).toBe("my-key");
+	});
+
 	test("addLineItem unknown product", async () => {
 		assert(cart, "cart not created");
 

--- a/src/services/shopping-list.test.ts
+++ b/src/services/shopping-list.test.ts
@@ -234,6 +234,30 @@ describe("Shopping List Update Actions", () => {
 		expect(response.body.message).toBe("A product with ID '123' not found.");
 	});
 
+	test("addLineItem by productID", async () => {
+		ctMock.clear();
+		ctMock.project().add("product", product);
+		ctMock.project().add("shopping-list", { ...shoppingList, lineItems: [] });
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/shopping-lists/${shoppingList.id}`)
+			.send({
+				version: 1,
+				actions: [
+					{
+						action: "addLineItem",
+						productId: product.id,
+						key: "my-key",
+					},
+				],
+			});
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(2);
+		expect(response.body.lineItems).toHaveLength(1);
+		expect(response.body.lineItems[0].key).toBeDefined();
+		expect(response.body.lineItems[0].key).toEqual("my-key");
+	});
+
 	test("removeLineItem", async () => {
 		const response = await supertest(ctMock.app)
 			.post(`/dummy/shopping-lists/${shoppingList.id}`)


### PR DESCRIPTION
Add support to key field in the addLineItem actions. 

CT docs: https://docs.commercetools.com/api/projects/carts#add-lineitem

