### PR TITLE
fix: add support for adding payment key

### DIFF
--- a/src/repositories/payment/index.ts
+++ b/src/repositories/payment/index.ts
@@ -24,6 +24,7 @@ export class PaymentRepository extends AbstractResourceRepository<"payment"> {
 	create(context: RepositoryContext, draft: PaymentDraft): Payment {
 		const resource: Payment = {
 			...getBaseResourceProperties(),
+			key: draft.key,
 			amountPlanned: createCentPrecisionMoney(draft.amountPlanned),
 			paymentMethodInfo: draft.paymentMethodInfo!,
 			paymentStatus: draft.paymentStatus


### PR DESCRIPTION
Commercetools allows to set a `key` when creating the payment (see: https://docs.commercetools.com/api/projects/payments#create-payment). This is currently not supported in the payment repository.