### PR TITLE
feat: add support for searching on availability in productsearch

### DIFF
--- a/.changeset/tall-bags-invite.md
+++ b/.changeset/tall-bags-invite.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add support for availability querying in product search

--- a/src/product-search.ts
+++ b/src/product-search.ts
@@ -36,8 +36,8 @@ export class ProductSearch {
 			acc.set(entry.sku, {
 				isOnStock: existingEntry?.isOnStock || entry.quantityOnStock > 0,
 				availableQuantity: existingEntry?.availableQuantity ?? 0 + entry.quantityOnStock,
-				// isOnStockForChannel: (existingEntry?.isOnStockForChannel ?? []).concat(entry.supplyChannel?.id ?? [])
-				// TODO: this approach doesn't make it possible to support multiple channels per product
+				// NOTE: This doesn't handle inventory entries for multiple channels,
+				// so it doesn't exactly replicate the behavior of the commercetools api.
 				isOnStockForChannel: existingEntry?.isOnStockForChannel ?? entry.supplyChannel?.id
 			});
 

--- a/src/product-search.ts
+++ b/src/product-search.ts
@@ -13,6 +13,12 @@ import { validateSearchQuery } from "./lib/searchQueryTypeChecker";
 import { applyPriceSelector } from "./priceSelector";
 import type { AbstractStorage } from "./storage";
 
+interface ProductVariantAvailability {
+	isOnStock: boolean;
+	availableQuantity: number;
+	isOnStockForChannel: string | undefined
+}
+
 export class ProductSearch {
 	protected _storage: AbstractStorage;
 
@@ -24,10 +30,24 @@ export class ProductSearch {
 		projectKey: string,
 		params: ProductSearchRequest,
 	): ProductPagedSearchResponse {
-		let resources = this._storage
+		const availabilityBySku = this._storage.all(projectKey, "inventory-entry").reduce((acc, entry) => {
+			const existingEntry = acc.get(entry.sku);
+
+			acc.set(entry.sku, {
+				isOnStock: existingEntry?.isOnStock || entry.quantityOnStock > 0,
+				availableQuantity: existingEntry?.availableQuantity ?? 0 + entry.quantityOnStock,
+				// isOnStockForChannel: (existingEntry?.isOnStockForChannel ?? []).concat(entry.supplyChannel?.id ?? [])
+				// TODO: this approach doesn't make it possible to support multiple channels per product
+				isOnStockForChannel: existingEntry?.isOnStockForChannel ?? entry.supplyChannel?.id
+			});
+
+			return acc;
+		}, new Map<string, ProductVariantAvailability>());
+
+		let productResources = this._storage
 			.all(projectKey, "product")
 			.map((r) =>
-				this.transform(r, params.productProjectionParameters?.staged ?? false),
+				this.transformProduct(r, params.productProjectionParameters?.staged ?? false, availabilityBySku),
 			)
 			.filter((p) => {
 				if (!(params.productProjectionParameters?.staged ?? false)) {
@@ -46,7 +66,7 @@ export class ProductSearch {
 				const matchFunc = parseSearchQuery(params.query);
 
 				// Filters can modify the output. So clone the resources first.
-				resources = resources.filter((resource) =>
+				productResources = productResources.filter((resource) =>
 					matchFunc(resource, markMatchingVariant),
 				);
 			} catch (err) {
@@ -63,7 +83,7 @@ export class ProductSearch {
 
 		// Apply the priceSelector
 		if (params.productProjectionParameters) {
-			applyPriceSelector(resources, {
+			applyPriceSelector(productResources, {
 				country: params.productProjectionParameters.priceCountry,
 				channel: params.productProjectionParameters.priceChannel,
 				customerGroup: params.productProjectionParameters.priceCustomerGroup,
@@ -76,7 +96,7 @@ export class ProductSearch {
 
 		const offset = params.offset || 0;
 		const limit = params.limit || 20;
-		const productProjectionsResult = resources.slice(offset, offset + limit);
+		const productProjectionsResult = productResources.slice(offset, offset + limit);
 
 		/**
 		 * Do not supply productProjection if productProjectionParameters are not given
@@ -100,7 +120,7 @@ export class ProductSearch {
 		);
 
 		return {
-			total: resources.length,
+			total: productResources.length,
 			offset: offset,
 			limit: limit,
 			results: results,
@@ -108,7 +128,7 @@ export class ProductSearch {
 		};
 	}
 
-	transform(product: Product, staged: boolean): ProductProjection {
+	transformProduct(product: Product, staged: boolean, availabilityBySku: Map<string, ProductVariantAvailability>): ProductProjection {
 		const obj = !staged
 			? product.masterData.current
 			: product.masterData.staged;
@@ -125,7 +145,10 @@ export class ProductSearch {
 			slug: obj.slug,
 			categories: obj.categories,
 			masterVariant: obj.masterVariant,
-			variants: obj.variants,
+			variants: obj.variants.map((variant) => ({
+				...variant,
+				availability: variant.sku ? availabilityBySku.get(variant.sku) : { isOnStock: false, availableQuantity: 0, isOnStockForChannel: [] },
+			})),
 			productType: product.productType,
 			hasStagedChanges: product.masterData.hasStagedChanges,
 			published: product.masterData.published,

--- a/src/product-search.ts
+++ b/src/product-search.ts
@@ -13,7 +13,7 @@ import { validateSearchQuery } from "./lib/searchQueryTypeChecker";
 import { applyPriceSelector } from "./priceSelector";
 import type { AbstractStorage } from "./storage";
 
-interface ProductVariantAvailability {
+interface ProductSearchVariantAvailability {
 	isOnStock: boolean;
 	availableQuantity: number;
 	isOnStockForChannel: string | undefined
@@ -42,7 +42,7 @@ export class ProductSearch {
 			});
 
 			return acc;
-		}, new Map<string, ProductVariantAvailability>());
+		}, new Map<string, ProductSearchVariantAvailability>());
 
 		let productResources = this._storage
 			.all(projectKey, "product")
@@ -128,7 +128,7 @@ export class ProductSearch {
 		};
 	}
 
-	transformProduct(product: Product, staged: boolean, availabilityBySku: Map<string, ProductVariantAvailability>): ProductProjection {
+	transformProduct(product: Product, staged: boolean, availabilityBySku: Map<string, ProductSearchVariantAvailability>): ProductProjection {
 		const obj = !staged
 			? product.masterData.current
 			: product.masterData.staged;

--- a/src/services/product.test.ts
+++ b/src/services/product.test.ts
@@ -21,7 +21,7 @@ import type {
 } from "@commercetools/platform-sdk";
 import assert from "assert";
 import supertest from "supertest";
-import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { CommercetoolsMock } from "../index";
 
 const productTypeDraft: ProductTypeDraft = {
@@ -506,6 +506,10 @@ describe("Product update actions", () => {
 			.send(unpublishedProductDraft);
 
 		expect(response.status).toBe(201);
+	});
+
+	afterAll(async () => {
+		ctMock.clear();
 	});
 
 	test("setAttribute masterVariant (staged)", async () => {
@@ -1504,94 +1508,69 @@ describe("Product update actions", () => {
 				?.myCustomField,
 		).toBe("MyRandomValue");
 	});
+});
 
-	// Test the general product search implementation
-	describe("Product Search - Generic", () => {
-		test("Pagination", async () => {
-			{
-				const body: ProductSearchRequest = {
-					productProjectionParameters: {
-						storeProjection: "dummy-store",
-						localeProjection: ["en-US"],
-						priceCurrency: "EUR",
-						priceChannel: "dummy-channel",
-						expand: ["categories[*]", "categories[*].ancestors[*]"],
-					},
-					limit: 24,
-				};
-				const response = await supertest(ctMock.app)
-					.post("/dummy/products/search")
-					.send(body);
+// Test the general product search implementation
+describe("Product Search - Generic", () => {
+	const ctMock = new CommercetoolsMock();
 
-				const pagedSearchResponse: ProductPagedSearchResponse = response.body;
-				expect(pagedSearchResponse.limit).toBe(24);
-				expect(pagedSearchResponse.offset).toBe(0);
-				expect(pagedSearchResponse.total).toBeGreaterThan(0);
+	beforeAll(async () => {
+		await beforeAllProductTests(ctMock);
 
-				// Deliberately not supported fow now
-				expect(pagedSearchResponse.facets).toEqual([]);
+		new Array(24).fill(null).forEach(async () => {
+			const response = await supertest(ctMock.app)
+				.post("/dummy/products")
+				.send(publishedProductDraft);
 
-				const results: ProductSearchResult[] = pagedSearchResponse.results;
-				expect(results).toBeDefined();
-				expect(results.length).toBeGreaterThan(0);
-
-				// Find product with sku "1337" to be part of the search results
-				const productFound = results.find(
-					(result) => result?.productProjection?.masterVariant?.sku === "1337",
-				);
-				expect(productFound).toBeDefined();
-
-				const priceCurrencyMatch = results.find((result) =>
-					result?.productProjection?.masterVariant?.prices?.find(
-						(price) => price?.value?.currencyCode === "EUR",
-					),
-				);
-				expect(priceCurrencyMatch).toBeDefined();
-			}
-			{
-				const body: ProductSearchRequest = {
-					limit: 88,
-					offset: 88,
-				};
-
-				const response = await supertest(ctMock.app)
-					.post("/dummy/products/search")
-					.send(body);
-
-				const pagedSearchResponse: ProductPagedSearchResponse = response.body;
-				expect(pagedSearchResponse.limit).toBe(88);
-				expect(pagedSearchResponse.offset).toBe(88);
-				expect(pagedSearchResponse.total).toBeGreaterThan(0);
-
-				// No results, since we start at offset 88
-				const results: ProductSearchResult[] = pagedSearchResponse.results;
-				expect(results).toBeDefined();
-				expect(results.length).toBe(0);
-
-				// Product with sku "1337" should not be part of the results
-				const productFound = results.find(
-					(result) => result?.productProjection?.masterVariant?.sku === "1337",
-				);
-				expect(productFound).toBeUndefined();
-			}
+			expect(response.status).toBe(201);
 		});
+	});
 
-		test("Filter on inventory", async () => {
+	test("Pagination", async () => {
+		{
 			const body: ProductSearchRequest = {
-				query: {
-					exact: {
-						field: "variants.availability.isOnStockForChannel",
-						value: "dummy-inventory-channel",
-					},
-				},
 				productProjectionParameters: {
 					storeProjection: "dummy-store",
 					localeProjection: ["en-US"],
 					priceCurrency: "EUR",
 					priceChannel: "dummy-channel",
+					expand: ["categories[*]", "categories[*].ancestors[*]"],
 				},
-				// TODO: the beforeEach creates 24 products
-				limit: 1,
+				limit: 24,
+			};
+			const response = await supertest(ctMock.app)
+				.post("/dummy/products/search")
+				.send(body);
+
+			const pagedSearchResponse: ProductPagedSearchResponse = response.body;
+			expect(pagedSearchResponse.limit).toBe(24);
+			expect(pagedSearchResponse.offset).toBe(0);
+			expect(pagedSearchResponse.total).toBeGreaterThan(0);
+
+			// Deliberately not supported fow now
+			expect(pagedSearchResponse.facets).toEqual([]);
+
+			const results: ProductSearchResult[] = pagedSearchResponse.results;
+			expect(results).toBeDefined();
+			expect(results.length).toBeGreaterThan(0);
+
+			// Find product with sku "1337" to be part of the search results
+			const productFound = results.find(
+				(result) => result?.productProjection?.masterVariant?.sku === "1337",
+			);
+			expect(productFound).toBeDefined();
+
+			const priceCurrencyMatch = results.find((result) =>
+				result?.productProjection?.masterVariant?.prices?.find(
+					(price) => price?.value?.currencyCode === "EUR",
+				),
+			);
+			expect(priceCurrencyMatch).toBeDefined();
+		}
+		{
+			const body: ProductSearchRequest = {
+				limit: 88,
+				offset: 88,
 			};
 
 			const response = await supertest(ctMock.app)
@@ -1599,13 +1578,51 @@ describe("Product update actions", () => {
 				.send(body);
 
 			const pagedSearchResponse: ProductPagedSearchResponse = response.body;
+			expect(pagedSearchResponse.limit).toBe(88);
+			expect(pagedSearchResponse.offset).toBe(88);
+			expect(pagedSearchResponse.total).toBeGreaterThan(0);
 
-			expect(pagedSearchResponse.results.length).toBe(1);
+			// No results, since we start at offset 88
+			const results: ProductSearchResult[] = pagedSearchResponse.results;
+			expect(results).toBeDefined();
+			expect(results.length).toBe(0);
 
-			const productFound = pagedSearchResponse.results.find(
+			// Product with sku "1337" should not be part of the results
+			const productFound = results.find(
 				(result) => result?.productProjection?.masterVariant?.sku === "1337",
 			);
-			expect(productFound).toBeDefined();
-		});
+			expect(productFound).toBeUndefined();
+		}
+	});
+
+	test("Filter on inventory", async () => {
+		const body: ProductSearchRequest = {
+			query: {
+				exact: {
+					field: "variants.availability.isOnStockForChannel",
+					value: "dummy-inventory-channel",
+				},
+			},
+			productProjectionParameters: {
+				storeProjection: "dummy-store",
+				localeProjection: ["en-US"],
+				priceCurrency: "EUR",
+				priceChannel: "dummy-channel",
+			},
+			limit: 1,
+		};
+
+		const response = await supertest(ctMock.app)
+			.post("/dummy/products/search")
+			.send(body);
+
+		const pagedSearchResponse: ProductPagedSearchResponse = response.body;
+
+		expect(pagedSearchResponse.results.length).toBe(1);
+
+		const productFound = pagedSearchResponse.results.find(
+			(result) => result?.productProjection?.masterVariant?.sku === "1337",
+		);
+		expect(productFound).toBeDefined();
 	});
 });

--- a/src/services/product.test.ts
+++ b/src/services/product.test.ts
@@ -1628,7 +1628,10 @@ describe("Product Search - Generic", () => {
 
 		expect(pagedSearchResponse1.results.length).toBe(0);
 
-		await addInventoryEntry(publishedProductDraft.variants?.[0]?.sku as string, 10);
+		await addInventoryEntry(
+			publishedProductDraft.variants?.[0]?.sku as string,
+			10,
+		);
 
 		const response2 = await supertest(ctMock.app)
 			.post("/dummy/products/search")

--- a/src/services/product.test.ts
+++ b/src/services/product.test.ts
@@ -21,7 +21,14 @@ import type {
 } from "@commercetools/platform-sdk";
 import assert from "assert";
 import supertest from "supertest";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "vitest";
 import { CommercetoolsMock } from "../index";
 
 const productTypeDraft: ProductTypeDraft = {
@@ -110,12 +117,12 @@ const productPriceTypeDraft: TypeDraft = {
 
 const inventoryEntryDraft: InventoryEntryDraft = {
 	key: "1338_stock",
-	sku: '1338',
+	sku: "1338",
 	quantityOnStock: 10,
 	supplyChannel: {
 		typeId: "channel",
 		id: "dummy-inventory-channel",
-	}
+	},
 };
 
 const publishedProductDraft: ProductDraft = {


### PR DESCRIPTION
### Context

The current product search mock doesn't take querying on stock availability into account. Commercetools allows searching on the product variants availability attributes: `availableQuantity`, `isOnStock` & `isOnStockForChannel`. These attributes are not by default available on each product, and needed to be added to the resources that are used for the product search.

### Changes

- Add availability object to each resource that is used for the product search
- Move product search tests to each own test suite, so it won't be affected by other tests.