### PR TITLE
Add processing of line item custom types on cart creation

### DIFF
--- a/.changeset/slow-parts-shine.md
+++ b/.changeset/slow-parts-shine.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Adds custom line item field handling on cart creation

--- a/src/repositories/cart/index.test.ts
+++ b/src/repositories/cart/index.test.ts
@@ -3,11 +3,21 @@ import { describe, expect, test } from "vitest";
 import type { Config } from "~src/config";
 import { InMemoryStorage } from "~src/storage";
 import { CartRepository } from "./index";
+import { getBaseResourceProperties } from "~src/helpers";
 
 describe("Cart repository", () => {
 	const storage = new InMemoryStorage();
 	const config: Config = { storage, strict: false };
 	const repository = new CartRepository(config);
+
+	storage.add("dummy", "type", {
+		...getBaseResourceProperties(),
+		id: "1234567890",
+		key: "custom-type-key",
+		name: { "nl-NL": "custom-type-name" },
+		resourceTypeIds: [],
+		fieldDefinitions: []
+	});
 
 	test("create cart in store", async () => {
 		storage.add("dummy", "product", {
@@ -108,6 +118,15 @@ describe("Cart repository", () => {
 							},
 						],
 					},
+					custom: {
+						type: {
+							typeId: "type",
+							id: "1234567890",
+						},
+						fields: {
+							description: "example description",
+						},
+					},
 				} as unknown as LineItem,
 			],
 			origin: "Customer",
@@ -149,5 +168,6 @@ describe("Cart repository", () => {
 		expect(result.taxMode).toEqual(cart.taxMode);
 		expect(result.taxRoundingMode).toEqual(cart.taxRoundingMode);
 		expect(result.store?.key).toEqual(ctx.storeKey);
+		expect(result.lineItems[0].custom?.fields.description as string).toEqual((cart.lineItems!)[0].custom?.fields?.description)
 	});
 });

--- a/src/repositories/cart/index.ts
+++ b/src/repositories/cart/index.ts
@@ -202,6 +202,7 @@ export class CartRepository extends AbstractResourceRepository<"cart"> {
 			lineItemMode: "Standard",
 			priceMode: "Platform",
 			state: [],
+			custom: createCustomFields(draftLineItem.custom, projectKey, this._storage),
 		};
 	};
 }


### PR DESCRIPTION
In the current state this mock service is able to handle custom line item fields if they are being sent of a cart update action. However, the service is not able to handle these custom fields upon cart creation.

This PR aims to fix that by adding the custom field handler.

The test additions are a bit crude, I'll happily change/remove them per your suggestions.