### PR TITLE
feat(me/business-units): add missing routes

### DIFF
--- a/.changeset/fresh-deer-invent.md
+++ b/.changeset/fresh-deer-invent.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+add missing "/me/business-units/\*" endpoints

--- a/src/services/my-business-unit.test.ts
+++ b/src/services/my-business-unit.test.ts
@@ -28,4 +28,86 @@ describe("MyBusinessUnit", () => {
 		expect(response.body.count).toBeGreaterThanOrEqual(0);
 		expect(response.body.results).toBeDefined();
 	});
+
+	test("Get my business unit by ID", async () => {
+		// First create a business unit
+		const draft: BusinessUnitDraft = {
+			key: "my-business-unit",
+			unitType: "Company",
+			name: "My Business Unit",
+			contactEmail: "contact@example.com",
+		};
+		const createResponse = await supertest(ctMock.app)
+			.post("/dummy/business-units")
+			.send(draft);
+
+		expect(createResponse.status).toBe(201);
+
+		const response = await supertest(ctMock.app).get(
+			`/dummy/me/business-units/${createResponse.body.id}`,
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual(createResponse.body);
+	});
+
+	test("Delete my business unit", async () => {
+		// First create a business unit
+		const draft: BusinessUnitDraft = {
+			key: "my-business-unit",
+			unitType: "Company",
+			name: "My Business Unit",
+			contactEmail: "contact@example.com",
+		};
+		const createResponse = await supertest(ctMock.app)
+			.post("/dummy/business-units")
+			.send(draft);
+
+		expect(createResponse.status).toBe(201);
+
+		// Now delete the business unit
+		const deleteResponse = await supertest(ctMock.app).delete(
+			`/dummy/me/business-units/${createResponse.body.id}`,
+		);
+
+		expect(deleteResponse.status).toBe(200);
+		expect(deleteResponse.body).toEqual(createResponse.body);
+
+		// Verify that the business unit is deleted
+		const newResponse = await supertest(ctMock.app).get(
+			`/dummy/me/business-units/${createResponse.body.id}`,
+		);
+		expect(newResponse.status).toBe(404);
+	});
+
+	test("Update my business unit", async () => {
+		// First create a business unit
+		const draft: BusinessUnitDraft = {
+			key: "my-business-unit",
+			unitType: "Company",
+			name: "My Business Unit",
+			contactEmail: "contact@example.com",
+		};
+		const createResponse = await supertest(ctMock.app)
+			.post("/dummy/business-units")
+			.send(draft);
+
+		expect(createResponse.status).toBe(201);
+
+		const updateResponse = await supertest(ctMock.app)
+			.post(`/dummy/me/business-units/${createResponse.body.id}`)
+			.send({
+				id: createResponse.body.id,
+				version: createResponse.body.version,
+				actions: [
+					{
+						action: "changeName",
+						name: "Updated Business Unit Name",
+					},
+				],
+			});
+
+		expect(updateResponse.status).toBe(200);
+		expect(updateResponse.body.name).toBe("Updated Business Unit Name");
+	});
 });

--- a/src/services/my-business-unit.ts
+++ b/src/services/my-business-unit.ts
@@ -22,6 +22,12 @@ export class MyBusinessUnitService extends AbstractService {
 		this.extraRoutes(router);
 
 		router.get("/business-units/", this.get.bind(this));
+		router.get("/business-units/:id", this.getWithId.bind(this));
+
+		router.delete("/business-units/:id", this.deleteWithId.bind(this));
+
+		router.post("/business-units/", this.post.bind(this));
+		router.post("/business-units/:id", this.postWithId.bind(this));
 
 		parent.use(`/${basePath}`, router);
 	}


### PR DESCRIPTION
Add support for get/delete/post endpoints of my-business-units.