### PR TITLE
fix: add support for attributes() function in predicate parser

### DIFF
--- a/.changeset/flat-hands-grow.md
+++ b/.changeset/flat-hands-grow.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Fix product-level attributes filtering in predicate parser to support attributes() function and handle array values in IN operator


### PR DESCRIPTION
## Description
This PR fixes product-level attribute filtering in the predicate parser, completing the product-level attributes support that was added in v2.55.0.

## Problem
While v2.55.0 added support for product-level attributes, the predicate parser didn't support the `attributes()` function for filtering. This made it impossible to query products by their attributes using WHERE clauses like:
```
attributes(name="stores" and value in ("test"))
```

## Solution
1. **Added support for `attributes()` function** in the predicate parser's led("(") handler
2. **Fixed IN operator** to handle array values (needed when attributes contain arrays)
3. **Updated resolveValue** to properly return the attributes array when requested

## Changes Made
- `src/lib/predicateParser.ts`: Added attributes() function support and fixed IN operator
- `src/lib/predicateParser.test.ts`: Added comprehensive test coverage (20 new test cases)

## Testing
✅ Added 20 new test cases covering:
- attributes() function with various data types
- IN operator with array values
- Combined predicates (AND/OR)
- Edge cases (empty arrays, missing attributes)

✅ All 538 existing tests still pass

## Breaking Changes
None - this is a backwards-compatible fix that enables previously non-functional queries.

## Example Usage
```typescript
// Now works correctly:
productProjections.get({
  queryArgs: {
    where: 'attributes(name="stores" and value in ("store1", "store2"))'
  }
})
```

## Implementation Details

### 1. Support for attributes() function
The predicate parser now recognizes when `attributes` is used as a function call and evaluates the inner expression against each attribute in the product's attributes array:

```typescript
if (left && left.value === "attributes") {
  if (Array.isArray(obj.attributes)) {
    return obj.attributes.some((attr: any) => {
      return expr(attr, vars);
    });
  }
  return false;
}
```

### 2. IN operator fix for array values
The IN operator now correctly handles cases where the left-hand value is an array, checking if any elements match:

```typescript
if (Array.isArray(value)) {
  return value.some(v => inValues.includes(v));
}
```

### 3. Attributes array resolution
The resolveValue function now properly returns the attributes array when requested:

```typescript
if (val.value === "attributes" && obj.attributes) {
  return obj.attributes;
}
```
