### PR TITLE
chore: update msw dependency to 2.8.4

### DIFF
--- a/.changeset/rich-pens-joke.md
+++ b/.changeset/rich-pens-joke.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+update MSW depedency to 2.8.4

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"express": "5.1.0",
 		"light-my-request": "6.6.0",
 		"morgan": "1.10.0",
-		"msw": "2.7.3",
+		"msw": "2.8.4",
 		"uuid": "11.1.0",
 		"zod": "3.24.2",
 		"zod-validation-error": "3.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 1.10.0
         version: 1.10.0
       msw:
-        specifier: 2.7.3
-        version: 2.7.3(@types/node@20.16.14)(typescript@5.8.3)
+        specifier: 2.8.4
+        version: 2.8.4(@types/node@20.16.14)(typescript@5.8.3)
       uuid:
         specifier: 11.1.0
         version: 11.1.0
@@ -80,7 +80,7 @@ importers:
         version: 9.0.8
       '@vitest/coverage-v8':
         specifier: 3.1.1
-        version: 3.1.1(vitest@3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1))
+        version: 3.1.1(vitest@3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1))
       esbuild:
         specifier: 0.25.2
         version: 0.25.2
@@ -101,7 +101,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.1.1
-        version: 3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1)
+        version: 3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1)
 
 packages:
 
@@ -1688,8 +1688,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.7.3:
-    resolution: {integrity: sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==}
+  msw@2.8.4:
+    resolution: {integrity: sha512-GLU8gx0o7RBG/3x/eTnnLd5S5ZInxXRRRMN8GJwaPZ4jpJTxzQfWGvwr90e8L5dkKJnz+gT4gQYCprLy/c4kVw==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -3071,7 +3071,7 @@ snapshots:
     dependencies:
       valibot: 1.0.0(typescript@5.8.3)
 
-  '@vitest/coverage-v8@3.1.1(vitest@3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1))':
+  '@vitest/coverage-v8@3.1.1(vitest@3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3085,7 +3085,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1)
+      vitest: 3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3096,13 +3096,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(vite@6.2.5(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(yaml@2.7.1))':
+  '@vitest/mocker@3.1.1(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(vite@6.2.5(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.3(@types/node@20.16.14)(typescript@5.8.3)
+      msw: 2.8.4(@types/node@20.16.14)(typescript@5.8.3)
       vite: 6.2.5(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.1.1':
@@ -3826,7 +3826,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3):
+  msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -4402,10 +4402,10 @@ snapshots:
       lightningcss: 1.29.3
       yaml: 2.7.1
 
-  vitest@3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1):
+  vitest@3.1.1(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(msw@2.7.3(@types/node@20.16.14)(typescript@5.8.3))(vite@6.2.5(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(yaml@2.7.1))
+      '@vitest/mocker': 3.1.1(msw@2.8.4(@types/node@20.16.14)(typescript@5.8.3))(vite@6.2.5(@types/node@20.16.14)(jiti@2.5.1)(lightningcss@1.29.3)(yaml@2.7.1))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1


### PR DESCRIPTION
This means getHandlers() will return `RequestHandler[]` instead of `HttpHandler[]`.