### PR TITLE
feat: add removeQuantity action

### DIFF
--- a/.changeset/old-sites-clean.md
+++ b/.changeset/old-sites-clean.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add removeQuantity action for inventory entries

--- a/src/repositories/inventory-entry/actions.ts
+++ b/src/repositories/inventory-entry/actions.ts
@@ -1,6 +1,7 @@
 import type {
 	InventoryEntry,
 	InventoryEntryChangeQuantityAction,
+	InventoryEntryRemoveQuantityAction,
 	InventoryEntrySetCustomFieldAction,
 	InventoryEntrySetCustomTypeAction,
 	InventoryEntrySetExpectedDeliveryAction,
@@ -24,6 +25,17 @@ export class InventoryEntryUpdateHandler
 		resource.quantityOnStock = quantity;
 		// don't know active reservations so just set to same value
 		resource.availableQuantity = quantity;
+	}
+
+	removeQuantity(
+		context: RepositoryContext,
+		resource: Writable<InventoryEntry>,
+		{ quantity }: InventoryEntryRemoveQuantityAction,
+	) {
+		const newQuantity = Math.max(0, resource.quantityOnStock - quantity);
+		resource.quantityOnStock = newQuantity;
+		// don't know active reservations so just set to same value
+		resource.availableQuantity = newQuantity;
 	}
 
 	setCustomField(

--- a/src/services/inventory-entry.test.ts
+++ b/src/services/inventory-entry.test.ts
@@ -93,6 +93,21 @@ describe("Inventory Entry Update Actions", () => {
 		expect(response.body.quantityOnStock).toBe(300);
 	});
 
+	test("removeQuantity", async () => {
+		assert(inventoryEntry, "inventory entry not created");
+
+		const response = await supertest(ctMock.app)
+			.post(`/dummy/inventory/${inventoryEntry.id}`)
+			.send({
+				version: 1,
+				actions: [{ action: "removeQuantity", quantity: 15 }],
+			});
+		expect(response.status).toBe(200);
+		expect(response.body.version).toBe(2);
+		expect(response.body.availableQuantity).toBe(85);
+		expect(response.body.quantityOnStock).toBe(85);
+	});
+
 	test("set custom type", async () => {
 		assert(inventoryEntry, "inventory entry not created");
 		assert(customType, "custom type not created");


### PR DESCRIPTION
This pull request introduces support for the `removeQuantity` action on inventory entries, allowing quantities to be subtracted from stock. The change includes both the implementation and a corresponding test to ensure correct behavior.

**Inventory entry actions:**

* Added the `removeQuantity` action to the `InventoryEntryUpdateHandler`, which decreases `quantityOnStock` and `availableQuantity` by the specified amount, ensuring the values do not go below zero. (`src/repositories/inventory-entry/actions.ts`, [[1]](diffhunk://#diff-861d61030e0231fbe9a417cfd51139b676940efcdc4d0fae7f19e9487d3532f1R4) [[2]](diffhunk://#diff-861d61030e0231fbe9a417cfd51139b676940efcdc4d0fae7f19e9487d3532f1R30-R40)

**Testing:**

* Added a test for the `removeQuantity` action to verify that the inventory entry's quantities are updated correctly when the action is used. (`src/services/inventory-entry.test.ts`, [src/services/inventory-entry.test.tsR96-R110](diffhunk://#diff-b679eb4155c512751fad7a0fd2f910a54086c7097ddbbcdfb4cd4ebe4a9cfde3R96-R110))

**Documentation:**

* Updated the changeset to document the addition of the `removeQuantity` action for inventory entries. (`.changeset/old-sites-clean.md`, [.changeset/old-sites-clean.mdR1-R5](diffhunk://#diff-27612412040630d66d6bec197223f696b30cebc93747a1ac4d46e39656b4f041R1-R5))