### PR TITLE
fix: correct reference to distfile in package.json

### DIFF
--- a/.changeset/wet-trains-sip.md
+++ b/.changeset/wet-trains-sip.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Fix release by properly referencing the `index.mjs` file in the package.json

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
 	"author": "Michael van Tellingen",
 	"type": "module",
 	"exports": {
-		".": "./dist/index.js"
+		".": "./dist/index.mjs"
 	},
 	"imports": {
 		"#src/*": "./src/*",
 		"#vendor/*": "./vendor/*"
 	},
-	"main": "dist/index.js",
-	"module": "dist/index.js",
+	"main": "dist/index.mjs",
+	"module": "dist/index.mjs",
 	"typings": "dist/index.d.ts",
 	"files": [
 		"dist",


### PR DESCRIPTION
This pull request fixes an issue with the package's entry point references to ensure the correct file is used for module resolution. The main change is updating all references from `index.js` to `index.mjs` in the `package.json`, which should resolve problems with package release and module loading.

Package entry point corrections:

* Updated the `exports`, `main`, and `module` fields in `package.json` to reference `dist/index.mjs` instead of `dist/index.js`, ensuring proper module resolution for consumers.
* Added a changeset describing the fix to ensure the release process documents this correction. (.changeset/wet-trains-sip.md)