### PR TITLE
fix: correct file ref to typings file

### DIFF
--- a/.changeset/cuddly-brooms-stare.md
+++ b/.changeset/cuddly-brooms-stare.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Fix file ref to typings file

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"main": "dist/index.mjs",
 	"module": "dist/index.mjs",
-	"typings": "dist/index.d.ts",
+	"typings": "dist/index.d.mts",
 	"files": [
 		"dist",
 		"src"


### PR DESCRIPTION
This pull request fixes a minor issue with the TypeScript typings file reference in the package configuration to ensure the correct file is used.

- Updated the `typings` field in `package.json` to point to `dist/index.d.mts` instead of `dist/index.d.ts`, correcting the file reference for TypeScript consumers.
- Documented this fix in a changeset file for release tracking.