### PR TITLE
feat: product search improvements

### DIFF
--- a/.changeset/free-numbers-kick.md
+++ b/.changeset/free-numbers-kick.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Support categoriesSubTree as field in Product Search

--- a/.changeset/nine-pans-fly.md
+++ b/.changeset/nine-pans-fly.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Parse Product Search not expressions values as array, instead of object

--- a/src/lib/productSearchFilter.test.ts
+++ b/src/lib/productSearchFilter.test.ts
@@ -83,11 +83,11 @@ describe("Product search filter", () => {
 
 		expect(
 			match({
-				not: {
+				not: [{
 					exists: {
 						field: "key",
 					},
-				},
+				}],
 			}).isMatch,
 		).toBeFalsy();
 
@@ -123,11 +123,11 @@ describe("Product search filter", () => {
 
 		expect(
 			match({
-				not: {
+				not: [{
 					exists: {
 						field: "variants.sku",
 					},
-				},
+				}],
 			}).isMatch,
 		).toBeFalsy();
 

--- a/src/lib/productSearchFilter.test.ts
+++ b/src/lib/productSearchFilter.test.ts
@@ -424,4 +424,81 @@ describe("Product search filter", () => {
 			).isMatch,
 		).toBeFalsy();
 	});
+
+	test("by categoriesSubTree", async () => {
+		const productWithCategories: ProductProjection = {
+			...exampleProduct,
+			categories: [
+				{
+					typeId: "category",
+					id: "category-1",
+					obj: {
+						id: "category-1",
+						version: 1,
+						createdAt: "2022-07-22T10:02:40.851Z",
+						lastModifiedAt: "2022-07-22T10:02:44.427Z",
+						name: {
+							"nl-NL": "Category 1",
+							"en-US": "Category 1",
+						},
+						slug: {
+							"nl-NL": "category-1",
+							"en-US": "category-1",
+						},
+						orderHint: "0.1",
+						ancestors: [
+							{
+								typeId: "category",
+								id: "ancestor-1",
+							},
+							{
+								typeId: "category",
+								id: "ancestor-2",
+							},
+						],
+					}
+				},
+				{
+					typeId: "category",
+					id: "category-2",
+				},
+			],
+		};
+
+		expect(
+			match(
+				{
+					exact: {
+						field: "categoriesSubTree",
+						value: "category-1",
+					},
+				},
+				productWithCategories,
+			).isMatch,
+		).toBeTruthy();
+
+		expect(
+			match(
+				{
+					exact: {
+						field: "categoriesSubTree",
+						value: "ancestor-1",
+					},
+				},
+				productWithCategories,
+			).isMatch,
+		).toBeTruthy();
+
+		expect(
+			match(
+				{
+					exact: {
+						field: "categoriesSubTree",
+						value: "other-category",
+					},
+				},
+				productWithCategories,
+			).isMatch,
+		).toBeFalsy();
+	});
 });

--- a/src/lib/productSearchFilter.test.ts
+++ b/src/lib/productSearchFilter.test.ts
@@ -83,11 +83,13 @@ describe("Product search filter", () => {
 
 		expect(
 			match({
-				not: [{
-					exists: {
-						field: "key",
+				not: [
+					{
+						exists: {
+							field: "key",
+						},
 					},
-				}],
+				],
 			}).isMatch,
 		).toBeFalsy();
 
@@ -123,11 +125,13 @@ describe("Product search filter", () => {
 
 		expect(
 			match({
-				not: [{
-					exists: {
-						field: "variants.sku",
+				not: [
+					{
+						exists: {
+							field: "variants.sku",
+						},
 					},
-				}],
+				],
 			}).isMatch,
 		).toBeFalsy();
 
@@ -456,7 +460,7 @@ describe("Product search filter", () => {
 								id: "ancestor-2",
 							},
 						],
-					}
+					},
 				},
 				{
 					typeId: "category",

--- a/src/lib/productSearchFilter.ts
+++ b/src/lib/productSearchFilter.ts
@@ -2,6 +2,8 @@ import type {
 	_SearchQuery,
 	_SearchQueryExpression,
 	_SearchQueryExpressionValue,
+	Category,
+	CategoryReference,
 	ProductProjection,
 	ProductVariant,
 	SearchAndExpression,
@@ -203,7 +205,11 @@ const generateFieldMatchFunc = (
 			return false;
 		}
 
-		return matchFunc(resolveFieldValue(obj, searchQuery));
+		const value = resolveFieldValue(obj, searchQuery);
+
+		return Array.isArray(value)
+			? value.some((v) => matchFunc(v))
+			: matchFunc(value);
 	};
 
 	return generateMatchFunc;
@@ -241,6 +247,18 @@ const resolveFieldValue = (
 		return obj.prices && obj.prices.length > 0
 			? obj.prices[0].value.centAmount
 			: undefined;
+	}
+
+	if (fieldPath === "categoriesSubTree") {
+		if (!Array.isArray(obj.categories) || obj.categories.length === 0) {
+			return undefined;
+		}
+
+		return obj.categories.flatMap((category: CategoryReference) => {
+			const ancestorIds = category.obj?.ancestors?.map((ancestor) => ancestor.id) ?? [];
+
+			return [category.id, ...ancestorIds];
+		});
 	}
 
 	return nestedLookupByLanguage(obj, fieldPath, language);

--- a/src/lib/productSearchFilter.ts
+++ b/src/lib/productSearchFilter.ts
@@ -2,7 +2,6 @@ import type {
 	_SearchQuery,
 	_SearchQueryExpression,
 	_SearchQueryExpressionValue,
-	Category,
 	CategoryReference,
 	ProductProjection,
 	ProductVariant,
@@ -56,7 +55,9 @@ export const parseSearchQuery = (
 
 	if (isSearchNotExpression(searchQuery)) {
 		return (obj, markMatchingVariant) =>
-			searchQuery.not.every((expr) => !parseSearchQuery(expr)(obj, markMatchingVariant));
+			searchQuery.not.every(
+				(expr) => !parseSearchQuery(expr)(obj, markMatchingVariant),
+			);
 	}
 
 	if (isSearchFilterExpression(searchQuery)) {
@@ -255,7 +256,8 @@ const resolveFieldValue = (
 		}
 
 		return obj.categories.flatMap((category: CategoryReference) => {
-			const ancestorIds = category.obj?.ancestors?.map((ancestor) => ancestor.id) ?? [];
+			const ancestorIds =
+				category.obj?.ancestors?.map((ancestor) => ancestor.id) ?? [];
 
 			return [category.id, ...ancestorIds];
 		});

--- a/src/lib/productSearchFilter.ts
+++ b/src/lib/productSearchFilter.ts
@@ -54,7 +54,7 @@ export const parseSearchQuery = (
 
 	if (isSearchNotExpression(searchQuery)) {
 		return (obj, markMatchingVariant) =>
-			!parseSearchQuery(searchQuery.not)(obj, markMatchingVariant);
+			searchQuery.not.every((expr) => !parseSearchQuery(expr)(obj, markMatchingVariant));
 	}
 
 	if (isSearchFilterExpression(searchQuery)) {

--- a/src/product-search.ts
+++ b/src/product-search.ts
@@ -1,4 +1,5 @@
 import type {
+	Category,
 	InvalidInputError,
 	InventoryEntry,
 	Product,
@@ -57,6 +58,14 @@ export class ProductSearch {
 			new Map<string, ProductSearchVariantAvailability>(),
 		);
 
+		const categories = await this._storage.all(projectKey, "category");
+		const categoriesById = categories.reduce(
+			(acc: Map<string, Category>, category: Category) => {
+				return acc.set(category.id, category);
+			},
+			new Map<string, Category>(),
+		);
+
 		const allProducts = await this._storage.all(projectKey, "product");
 		let productResources = allProducts
 			.map((r: Product) =>
@@ -64,6 +73,7 @@ export class ProductSearch {
 					r,
 					params.productProjectionParameters?.staged ?? false,
 					availabilityBySku,
+					categoriesById,
 				),
 			)
 			.filter((p: ProductProjection) => {
@@ -151,6 +161,7 @@ export class ProductSearch {
 		product: Product,
 		staged: boolean,
 		availabilityBySku: Map<string, ProductSearchVariantAvailability>,
+		categoriesById: Map<string, Category>,
 	): ProductProjection {
 		const obj = !staged
 			? product.masterData.current
@@ -183,7 +194,10 @@ export class ProductSearch {
 			description: obj.description,
 			metaDescription: obj.metaDescription,
 			slug: obj.slug,
-			categories: obj.categories,
+			categories: obj.categories.map((category) => ({
+				...category,
+				obj: categoriesById.get(category.id),
+			})),
 			attributes: obj.attributes,
 			masterVariant: {
 				...obj.masterVariant,


### PR DESCRIPTION
Changes:
- Small fix for `not` expression in Product Search: it now correctly accepts an array instead of an object as value.
- Adds support for the categoriesSubTree field in the Product Search: it matches the categoryId with a category id or it's ancestors.
 