### PR TITLE
fix: include root package in pnpm workspace (repairs release workflow)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - '.'
   - docs
 minimumReleaseAge: 20160
 trustPolicy: no-downgrade


### PR DESCRIPTION
## Problem

The docs PR (#402) added `packages: [docs]` to `pnpm-workspace.yaml`. That made
changesets/manypkg treat the root library as the excluded *root package*, so the
`release` job now fails:

```
Error: Found changeset ... for package @labdigital/commercetools-mock which is not in the workspace
```

(pnpm itself still shows the root project, but manypkg — which changesets uses — does not.)

## Fix

List the root explicitly alongside docs:

```yaml
packages:
  - '.'
  - docs
```

## Verified locally

- `pnpm changeset status` → `@labdigital/commercetools-mock` bumped at minor ✅
- `pnpm --filter @labdigital/commercetools-mock-docs build` → 26 pages ✅
- `pnpm check` (biome + tsc) → 322 files, no errors ✅