### PR TITLE
feat: apply the sort query parameter

### DIFF
--- a/.changeset/wild-pandas-listen.md
+++ b/.changeset/wild-pandas-listen.md
@@ -1,0 +1,19 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Apply the `sort` query parameter.
+
+`sort` was accepted and typed but never applied, so `query()` returned resources
+in insertion order. Cursor-based paging — `sort: "id asc"` with
+`where: 'id > "<last>"'`, which is how consumers walk a large collection — quietly
+skipped resources against the mock while being correct against the real API.
+
+Supports `field`, `field asc` and `field desc`, dot-separated paths
+(`name.en-GB`), and several clauses passed as an array. Numbers compare
+numerically; everything else compares as a string, which orders ISO timestamps
+correctly. Strings use `<`/`>` rather than a locale-aware comparison so that
+sorting and the `where` predicate agree on the ordering — without that, a cursor
+can step over resources. A missing value counts as larger than any present one,
+so it sorts last ascending and first descending. Sorting is applied before
+`offset`/`limit`, and is stable.

--- a/src/lib/sortParser.test.ts
+++ b/src/lib/sortParser.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+import { applySort, parseSortClauses } from "./sortParser.ts";
+
+describe("parseSortClauses", () => {
+	test("defaults to ascending", () => {
+		expect(parseSortClauses("id")).toEqual([
+			{ path: ["id"], direction: "asc" },
+		]);
+	});
+
+	test("reads an explicit direction", () => {
+		expect(parseSortClauses("createdAt desc")).toEqual([
+			{ path: ["createdAt"], direction: "desc" },
+		]);
+		expect(parseSortClauses("createdAt DESC")).toEqual([
+			{ path: ["createdAt"], direction: "desc" },
+		]);
+	});
+
+	test("splits a dot path", () => {
+		expect(parseSortClauses("name.en-GB asc")).toEqual([
+			{ path: ["name", "en-GB"], direction: "asc" },
+		]);
+	});
+
+	test("takes several clauses, as a repeated query parameter", () => {
+		expect(parseSortClauses(["key asc", "createdAt desc"])).toEqual([
+			{ path: ["key"], direction: "asc" },
+			{ path: ["createdAt"], direction: "desc" },
+		]);
+	});
+
+	test("tolerates extra whitespace and empty clauses", () => {
+		expect(parseSortClauses("  id   asc  ")).toEqual([
+			{ path: ["id"], direction: "asc" },
+		]);
+		expect(parseSortClauses(["", "id"])).toEqual([
+			{ path: ["id"], direction: "asc" },
+		]);
+	});
+
+	test("returns nothing when unset", () => {
+		expect(parseSortClauses(undefined)).toEqual([]);
+	});
+});
+
+describe("applySort", () => {
+	const resources = [
+		{ id: "c", version: 2, key: "x", name: { "en-GB": "Beta" } },
+		{ id: "a", version: 10, key: "x", name: { "en-GB": "alpha" } },
+		{ id: "b", version: 1, name: {} },
+	];
+
+	const ids = (input: { id: string }[]) => input.map((entry) => entry.id);
+
+	test("sorts ascending by default", () => {
+		expect(ids(applySort(resources, "id"))).toEqual(["a", "b", "c"]);
+	});
+
+	test("sorts descending", () => {
+		expect(ids(applySort(resources, "id desc"))).toEqual(["c", "b", "a"]);
+	});
+
+	test("compares numbers numerically, not as strings", () => {
+		// "10" < "2" as strings, which is the bug this guards against.
+		expect(ids(applySort(resources, "version asc"))).toEqual(["b", "c", "a"]);
+	});
+
+	test("follows a dot path", () => {
+		expect(ids(applySort(resources, "name.en-GB asc"))).toEqual([
+			"c",
+			"a",
+			"b",
+		]);
+	});
+
+	test("treats a missing value as the largest, so direction applies to it", () => {
+		// Last ascending, first descending — SQL's rule. The property that matters
+		// for a cursor is only that the order is total and deterministic.
+		expect(ids(applySort(resources, "name.en-GB asc")).at(-1)).toBe("b");
+		expect(ids(applySort(resources, "name.en-GB desc")).at(0)).toBe("b");
+	});
+
+	test("breaks ties with a second clause", () => {
+		expect(ids(applySort(resources, ["key asc", "id desc"]))).toEqual([
+			"c",
+			"a",
+			"b",
+		]);
+	});
+
+	test("is stable, so equal resources keep their order", () => {
+		const equal = [
+			{ id: "1", key: "k" },
+			{ id: "2", key: "k" },
+		];
+
+		expect(ids(applySort(equal, "key asc"))).toEqual(["1", "2"]);
+	});
+
+	test("does not mutate the input", () => {
+		const input = [{ id: "b" }, { id: "a" }];
+		applySort(input, "id asc");
+
+		expect(ids(input)).toEqual(["b", "a"]);
+	});
+
+	test("returns the input unchanged when there is no sort", () => {
+		expect(ids(applySort(resources, undefined))).toEqual(["c", "a", "b"]);
+	});
+
+	test("orders strings the same way the predicate parser compares them", () => {
+		// The invariant that makes cursor paging work: `sort id asc` must agree with
+		// `where id > "..."`. Both use plain `<`/`>` on the string, so a
+		// locale-aware comparison here would silently skip resources during paging.
+		const mixed = [{ id: "b" }, { id: "B" }, { id: "a" }, { id: "A" }];
+		const sorted = ids(applySort(mixed, "id asc"));
+
+		expect(sorted).toEqual(["A", "B", "a", "b"]);
+		for (let index = 1; index < sorted.length; index++) {
+			expect(sorted[index] > sorted[index - 1]).toBe(true);
+		}
+	});
+
+	test("sorts ISO timestamps chronologically", () => {
+		const dated = [
+			{ id: "late", createdAt: "2026-02-01T00:00:00.000Z" },
+			{ id: "early", createdAt: "2026-01-15T23:59:59.000Z" },
+		];
+
+		expect(ids(applySort(dated, "createdAt asc"))).toEqual(["early", "late"]);
+	});
+});

--- a/src/lib/sortParser.ts
+++ b/src/lib/sortParser.ts
@@ -1,0 +1,122 @@
+export type SortDirection = "asc" | "desc";
+
+export type SortClause = {
+	/** Dot-separated field path, already split. */
+	path: string[];
+	direction: SortDirection;
+};
+
+/**
+ * Parse commercetools `sort` parameters.
+ *
+ * The syntax is `field` or `field asc` / `field desc`, and the parameter may be
+ * repeated for a secondary sort — which the SDK passes as an array. A missing
+ * direction means ascending.
+ */
+export const parseSortClauses = (
+	sort: string | string[] | undefined,
+): SortClause[] => {
+	if (sort === undefined) {
+		return [];
+	}
+
+	const clauses = Array.isArray(sort) ? sort : [sort];
+
+	return clauses.flatMap((clause) => {
+		const [field, direction] = clause.trim().split(/\s+/);
+		if (!field) {
+			return [];
+		}
+
+		return [
+			{
+				path: field.split("."),
+				direction: direction?.toLowerCase() === "desc" ? "desc" : "asc",
+			},
+		];
+	});
+};
+
+const resolvePath = (resource: unknown, path: string[]): unknown => {
+	let current = resource;
+
+	for (const segment of path) {
+		if (current === null || typeof current !== "object") {
+			return undefined;
+		}
+		current = (current as Record<string, unknown>)[segment];
+	}
+
+	return current;
+};
+
+/**
+ * Compare two field values.
+ *
+ * Strings use `<` and `>` rather than `localeCompare`, deliberately: the
+ * predicate parser compares with the same operators, so a `where id > "..."`
+ * cursor and a `sort id asc` have to agree on the ordering or paging silently
+ * skips resources. It also matches the API for the values that get sorted on in
+ * practice — ids, keys and ISO timestamps.
+ */
+const compareValues = (left: unknown, right: unknown): number => {
+	// A missing value counts as larger than any present one, and the requested
+	// direction then applies — so it sorts last ascending and first descending,
+	// the same rule SQL uses. What matters either way is that the order is total
+	// and deterministic, or a cursor cannot page through it.
+	if (left === undefined || left === null) {
+		return right === undefined || right === null ? 0 : 1;
+	}
+	if (right === undefined || right === null) {
+		return -1;
+	}
+
+	if (typeof left === "number" && typeof right === "number") {
+		return left - right;
+	}
+	if (typeof left === "boolean" && typeof right === "boolean") {
+		return Number(left) - Number(right);
+	}
+
+	// Anything else compares as a string, which covers ISO dates correctly since
+	// their lexicographic and chronological orders coincide.
+	const leftText = String(left);
+	const rightText = String(right);
+	if (leftText < rightText) {
+		return -1;
+	}
+	if (leftText > rightText) {
+		return 1;
+	}
+	return 0;
+};
+
+/**
+ * Sort resources by the given clauses.
+ *
+ * Returns the input unchanged when there is nothing to sort by. The sort is
+ * stable, so resources that compare equal keep their existing order and a
+ * secondary clause only breaks ties from the first.
+ */
+export const applySort = <T>(
+	resources: T[],
+	sort: string | string[] | undefined,
+): T[] => {
+	const clauses = parseSortClauses(sort);
+	if (clauses.length === 0) {
+		return resources;
+	}
+
+	return [...resources].sort((left, right) => {
+		for (const clause of clauses) {
+			const result = compareValues(
+				resolvePath(left, clause.path),
+				resolvePath(right, clause.path),
+			);
+			if (result !== 0) {
+				return clause.direction === "desc" ? -result : result;
+			}
+		}
+		return 0;
+	});
+};

--- a/src/storage/in-memory.ts
+++ b/src/storage/in-memory.ts
@@ -41,6 +41,7 @@ import type {
 import { CommercetoolsError } from "#src/exceptions.ts";
 import { cloneObject } from "../helpers.ts";
 import { parseQueryExpression } from "../lib/predicateParser.ts";
+import { applySort } from "../lib/sortParser.ts";
 import type {
 	PagedQueryResponseMap,
 	ResourceMap,
@@ -342,6 +343,10 @@ export class InMemoryStorage extends AbstractStorage {
 				);
 			}
 		}
+
+		// Apply sorting before paging: a cursor-based pager (`where id > "..."`
+		// with `sort id asc`) depends on a deterministic order.
+		resources = applySort(resources, params.sort);
 
 		// Get the total before slicing the array
 		const totalResources = resources.length;

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -8,6 +8,7 @@ import type {
 import { CommercetoolsError } from "#src/exceptions.ts";
 import { cloneObject } from "../helpers.ts";
 import { parseQueryExpression } from "../lib/predicateParser.ts";
+import { applySort } from "../lib/sortParser.ts";
 import type {
 	PagedQueryResponseMap,
 	ResourceMap,
@@ -400,6 +401,10 @@ export class SQLiteStorage extends AbstractStorage {
 				);
 			}
 		}
+
+		// Apply sorting before paging: a cursor-based pager (`where id > "..."`
+		// with `sort id asc`) depends on a deterministic order.
+		resources = applySort(resources, params.sort);
 
 		// Get the total before slicing the array
 		const totalResources = resources.length;

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -412,14 +412,16 @@ describe(`Storage (${storageEngineName})`, () => {
 			expect(seen).toEqual([...seen].sort());
 		});
 
-		test("leaves order untouched without a sort", async () => {
-			const result = await storage.query(projectKey, "category", { limit: 3 });
+		test("returns a stable order without a sort", async () => {
+			// Which order that is belongs to the backend — in-memory keeps insertion
+			// order, sqlite returns rows by id — so only the guarantee both make is
+			// asserted here: repeating a query does not reshuffle it.
+			const first = await storage.query(projectKey, "category", { limit: 5 });
+			const second = await storage.query(projectKey, "category", { limit: 5 });
 
-			expect(result.results.map((entry) => entry.id)).toEqual([
-				"cat-1",
-				"cat-2",
-				"cat-3",
-			]);
+			expect(second.results.map((entry) => entry.id)).toEqual(
+				first.results.map((entry) => entry.id),
+			);
 		});
 	});
 

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -333,6 +333,94 @@ describe(`Storage (${storageEngineName})`, () => {
 			const fresh = await storage.query(projectKey, "category", { limit: 1 });
 			expect(fresh.results[0].name).not.toEqual({ en: "Mutated" });
 		});
+
+		test("sorts ascending", async () => {
+			const result = await storage.query(projectKey, "category", {
+				sort: "id asc",
+				limit: 3,
+			});
+
+			expect(result.results.map((entry) => entry.id)).toEqual([
+				"cat-1",
+				"cat-10",
+				"cat-11",
+			]);
+		});
+
+		test("sorts descending", async () => {
+			const result = await storage.query(projectKey, "category", {
+				sort: "id desc",
+				limit: 2,
+			});
+
+			expect(result.results.map((entry) => entry.id)).toEqual([
+				"cat-9",
+				"cat-8",
+			]);
+		});
+
+		test("sorts on a nested field", async () => {
+			const result = await storage.query(projectKey, "category", {
+				sort: "name.en desc",
+				limit: 1,
+			});
+
+			expect(result.results[0].name).toEqual({ en: "Category 9" });
+		});
+
+		test("sorts before paging, not after", async () => {
+			// Slicing first and sorting the page would make each page internally
+			// ordered but the sequence across pages meaningless.
+			const first = await storage.query(projectKey, "category", {
+				sort: "id asc",
+				limit: 10,
+			});
+			const second = await storage.query(projectKey, "category", {
+				sort: "id asc",
+				limit: 10,
+				offset: 10,
+			});
+
+			const ids = [...first.results, ...second.results].map((e) => e.id);
+			expect(ids).toEqual([...ids].sort());
+		});
+
+		test("supports cursor paging with a where predicate", async () => {
+			// The pattern every commercetools consumer uses to walk a large
+			// collection: sort by id, then ask for everything after the last id seen.
+			// It only terminates and only visits each resource once if sort and
+			// predicate agree on the ordering.
+			const seen: string[] = [];
+			let lastId: string | undefined;
+
+			for (;;) {
+				const page = await storage.query(projectKey, "category", {
+					where: lastId ? `id > "${lastId}"` : undefined,
+					sort: "id asc",
+					limit: 4,
+				});
+
+				seen.push(...page.results.map((entry) => entry.id));
+				if (page.results.length < 4) {
+					break;
+				}
+				lastId = page.results[page.results.length - 1].id;
+			}
+
+			expect(seen).toHaveLength(25);
+			expect(new Set(seen).size).toBe(25);
+			expect(seen).toEqual([...seen].sort());
+		});
+
+		test("leaves order untouched without a sort", async () => {
+			const result = await storage.query(projectKey, "category", { limit: 3 });
+
+			expect(result.results.map((entry) => entry.id)).toEqual([
+				"cat-1",
+				"cat-2",
+				"cat-3",
+			]);
+		});
 	});
 
 	describe("search", () => {


### PR DESCRIPTION
## The problem

`sort` is accepted and typed on `QueryParams` (`src/storage/abstract.ts:32`) but never applied. `query()` goes from `where`-filtering straight to `resources.slice(offset, offset + limit)`, so results come back in insertion order.

Where that bites is cursor paging:

```ts
sort: "id asc"
where: `id > "${lastId}"`
```

which is how consumers walk a collection larger than one page — `iterateProductPages`, `getStores` and similar helpers in downstream projects all use it. Against the mock the cursor is taken from the last row of an *unsorted* page, so it is not the maximum id seen and the next query skips resources. The same code is correct against the real API, so a test written against the mock passes or fails for the wrong reason. I hit both while writing a paging-heavy feature and had to demote the data-level assertions to request-level ones.

## The fix

`src/lib/sortParser.ts` — `parseSortClauses` + `applySort`, called from both the in-memory and sqlite backends after `where` and before `offset`/`limit`.

Supports `field`, `field asc`, `field desc`, dot-separated paths (`name.en-GB`), and several clauses passed as an array (which is how a repeated `sort` parameter arrives). Numbers compare numerically — `"10" < "2"` as strings is the trap. Everything else compares as a string, which orders ISO timestamps correctly. Stable, so a secondary clause only breaks ties from the first.

## Two decisions worth a look

**Strings compare with `<` / `>`, not `localeCompare`.** `predicateParser` compares with those same operators (`src/lib/predicateParser.ts:313`). If sorting and the `where` predicate disagreed on ordering, a cursor could step *over* resources — the exact bug being fixed here. There is a test asserting `["A", "B", "a", "b"]` and that each element is `>` its predecessor.

**A missing value counts as larger than any present one**, so it sorts last ascending and first descending, as SQL does. I could not verify commercetools' actual rule for this, so I picked the one that yields a total, deterministic order and documented it rather than guessing at fidelity. Happy to change it if someone knows the real behaviour.

## Testing

- `src/lib/sortParser.test.ts` — 17 tests: parsing, directions, dot paths, numeric vs string comparison, missing values, tie-breaking, stability, no input mutation, predicate agreement, ISO timestamps.
- `src/storage/storage.test.ts` — 6 tests in the existing `query` block, including one that pages 25 categories in fours with a cursor and asserts all 25 are seen exactly once, in order. Runs against both storage backends.
- All 784 tests pass (761 pre-existing, 23 new). `biome check && tsc` clean.

Changeset included as a `minor`.