### PR TITLE
fix: apply sort on product-projections

### DIFF
--- a/.changeset/lucky-moons-wander.md
+++ b/.changeset/lucky-moons-wander.md
@@ -1,0 +1,15 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Apply `sort` on `/product-projections` too.
+
+`ProductProjectionRepository.query()` does not go through
+`AbstractStorage.query()` — it transforms products itself, then filters, expands
+and slices — so it did not pick up the `sort` support added in 4.3.0, even though
+`ProductProjectionQueryParams` declares the parameter.
+
+That left the endpoint most likely to be walked with a cursor
+(`sort: "id asc"` with `where: 'id > "<last>"'`) still returning products in
+insertion order, so such a walk skipped products against the mock while being
+correct against the real API.

--- a/src/repositories/product-projection.ts
+++ b/src/repositories/product-projection.ts
@@ -8,6 +8,7 @@ import type {
 import type { Config } from "#src/config.ts";
 import { CommercetoolsError } from "#src/exceptions.ts";
 import { parseQueryExpression } from "../lib/predicateParser.ts";
+import { applySort } from "../lib/sortParser.ts";
 import { applyPriceSelector } from "../priceSelector.ts";
 import { ProductProjectionSearch } from "../product-projection-search.ts";
 import type { GetParams, RepositoryContext } from "./abstract.ts";
@@ -140,6 +141,12 @@ export class ProductProjectionRepository extends AbstractResourceRepository<"pro
 				),
 			);
 		}
+
+		// Sort before paging. This repository does not go through
+		// AbstractStorage.query, so it needs its own call — without it a
+		// cursor-paged walk (`sort: "id asc"` with `where: 'id > "<last>"'`) takes
+		// its cursor from an unsorted page and skips products.
+		resources = applySort(resources, params.sort);
 
 		// Create a slice for the pagination. If we were working with large datasets
 		// then we should have done this before transforming. But that isn't the

--- a/src/services/product-projection.test.ts
+++ b/src/services/product-projection.test.ts
@@ -636,3 +636,87 @@ describe("Product Projection Search - Facets", () => {
 		});
 	});
 });
+
+describe("Product Projection Query - sorting", () => {
+	const many = 6;
+
+	beforeEach(async () => {
+		for (let index = 0; index < many; index++) {
+			await productFactory.create({
+				publish: true,
+				key: `sortable-${index}`,
+				name: { "nl-NL": `sortable ${index}` },
+				slug: { "nl-NL": `sortable-${index}` },
+				masterVariant: { sku: `sortable-sku-${index}` },
+			});
+		}
+	});
+
+	const query = async (
+		params: Record<string, string>,
+	): Promise<ProductProjectionPagedSearchResponse> => {
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/product-projections",
+			query: params,
+		});
+		return response.json();
+	};
+
+	test("sorts ascending by id", async () => {
+		const result = await query({ sort: "id asc", limit: "50" });
+		const ids = result.results.map((entry) => entry.id);
+
+		expect(ids).toEqual([...ids].sort());
+	});
+
+	test("sorts descending by id", async () => {
+		const result = await query({ sort: "id desc", limit: "50" });
+		const ids = result.results.map((entry) => entry.id);
+
+		expect(ids).toEqual([...ids].sort().reverse());
+	});
+
+	test("sorts on a localized field", async () => {
+		const result = await query({ sort: "name.nl-NL asc", limit: "50" });
+		const names = result.results.map((entry) => entry.name["nl-NL"]);
+
+		expect(names).toEqual([...names].sort());
+	});
+
+	test("sorts before paging, not within a page", async () => {
+		const first = await query({ sort: "id asc", limit: "3" });
+		const second = await query({ sort: "id asc", limit: "3", offset: "3" });
+		const ids = [...first.results, ...second.results].map((entry) => entry.id);
+
+		expect(ids).toEqual([...ids].sort());
+	});
+
+	test("supports cursor paging with a where predicate", async () => {
+		// How a consumer walks a catalog larger than one page. It only terminates
+		// and only visits each product once if `sort` and `where` agree on the
+		// ordering — which is what this repository was missing.
+		const seen: string[] = [];
+		let lastId: string | undefined;
+
+		for (;;) {
+			const page = await query({
+				...(lastId ? { where: `id > "${lastId}"` } : {}),
+				sort: "id asc",
+				limit: "2",
+			});
+
+			seen.push(...page.results.map((entry) => entry.id));
+			if (page.results.length < 2) {
+				break;
+			}
+			lastId = page.results[page.results.length - 1].id;
+		}
+
+		// Every published product exactly once: the ones created here plus the
+		// published product from the outer setup.
+		expect(seen).toHaveLength(many + 1);
+		expect(new Set(seen).size).toBe(many + 1);
+		expect(seen).toEqual([...seen].sort());
+	});
+});


### PR DESCRIPTION
Follow-up to #405, which was incomplete for the endpoint that motivated it.

## What was missed

`ProductProjectionRepository.query()` does not delegate to `AbstractStorage.query()`. It reads all products, transforms them to projections, then filters with the `where` predicate, applies price selection, expands and slices — a parallel implementation of the same pipeline. So it never picked up #405's sort support, even though `ProductProjectionQueryParams` declares `sort?: string | string[]`.

The result: `/product-projections` still returned products in insertion order, which is exactly the case #405 set out to fix. A cursor-paged walk

```ts
sort: "id asc"
where: `id > "${lastId}"`
```

takes its cursor from the last row of an unsorted page — not the highest id seen — and skips products. #405's own tests passed because they exercised the storage layer, where the fix does apply.

I found this while bumping a downstream project to 4.3.0 and re-enabling the paging tests I had demoted because of the original bug; they still failed.

`product-projection.ts` is the only repository with its own query path — everything else goes through `AbstractStorage`, so nothing else is affected. Checked with:

```sh
grep -rln "async query(" src/repositories/   # product-projection.ts, abstract.ts
```

## The fix

One `applySort(resources, params.sort)` call before the pagination slice, reusing the parser from #405.

## Testing

Five tests in `src/services/product-projection.test.ts`, driven through the HTTP layer rather than the repository, so they cover the route as a consumer sees it:

- ascending and descending by `id`
- a localized field (`name.nl-NL`)
- sorting happens before paging, not within a page
- a cursor-paged walk in pages of two that visits every published product exactly once, in order

I verified they fail without the fix — reverting `product-projection.ts` alone fails all five.

789 tests pass on both storage backends (`in-memory` and `sqlite`), `biome check && tsc` clean. Changeset included as a `patch`.