### PR TITLE
feat: support changeQuoteRequestState on quote requests

### DIFF
--- a/.changeset/quote-request-change-state.md
+++ b/.changeset/quote-request-change-state.md
@@ -1,0 +1,12 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Support the `changeQuoteRequestState` update action on quote requests.
+
+The quote-request update handler implemented `setCustomField`, `setCustomType`
+and `transitionState`, but not `changeQuoteRequestState` — so a buyer
+cancelling a quote request, which maps to that action, could not be exercised
+against the mock. `transitionState` is not a substitute: it moves a quote
+request through a custom State machine, while `changeQuoteRequestState` sets
+the built-in `quoteRequestState` enum.

--- a/src/repositories/quote-request/actions.ts
+++ b/src/repositories/quote-request/actions.ts
@@ -1,6 +1,7 @@
 import type {
 	InvalidJsonInputError,
 	QuoteRequest,
+	QuoteRequestChangeQuoteRequestStateAction,
 	QuoteRequestSetCustomFieldAction,
 	QuoteRequestSetCustomTypeAction,
 	QuoteRequestTransitionStateAction,
@@ -18,6 +19,14 @@ export class QuoteRequestUpdateHandler
 	implements
 		Partial<UpdateHandlerInterface<QuoteRequest, QuoteRequestUpdateAction>>
 {
+	changeQuoteRequestState(
+		context: RepositoryContext,
+		resource: Writable<QuoteRequest>,
+		{ quoteRequestState }: QuoteRequestChangeQuoteRequestStateAction,
+	) {
+		resource.quoteRequestState = quoteRequestState;
+	}
+
 	setCustomField(
 		context: RepositoryContext,
 		resource: QuoteRequest,

--- a/src/services/quote-request.test.ts
+++ b/src/services/quote-request.test.ts
@@ -54,3 +54,54 @@ describe("Quote Request Create", () => {
 		});
 	});
 });
+
+describe("Quote Request Update", () => {
+	const ctMock = new CommercetoolsMock();
+	const customerFactory = customerDraftFactory(ctMock);
+	const cartFactory = cartDraftFactory(ctMock);
+	const quoteRequestFactory = quoteRequestDraftFactory(ctMock);
+
+	afterEach(async () => {
+		await ctMock.clear();
+	});
+
+	const createQuoteRequest = async () => {
+		const customer = await customerFactory.create();
+		const cart = await cartFactory.create({
+			currency: "EUR",
+			customerId: customer.id,
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/quote-requests",
+			payload: quoteRequestFactory.build({
+				cart: { typeId: "cart", id: cart.id },
+				cartVersion: cart.version,
+			}),
+		});
+
+		expect(response.statusCode).toBe(201);
+		return response.json();
+	};
+
+	it("should change the quote request state", async () => {
+		const quoteRequest = await createQuoteRequest();
+		expect(quoteRequest.quoteRequestState).toBe("Submitted");
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/quote-requests/${quoteRequest.id}`,
+			payload: {
+				version: quoteRequest.version,
+				actions: [
+					{ action: "changeQuoteRequestState", quoteRequestState: "Cancelled" },
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().quoteRequestState).toBe("Cancelled");
+		expect(response.json().version).toBe(quoteRequest.version + 1);
+	});
+});


### PR DESCRIPTION
The quote-request update handler implements `setCustomField`, `setCustomType` and `transitionState`, but not `changeQuoteRequestState` — so cancelling a quote request, which maps to that action, cannot be exercised against the mock.

`transitionState` is not a substitute for it. It moves a quote request through a custom `State` machine; `changeQuoteRequestState` sets the built-in `quoteRequestState` enum. The SDK declares them as two distinct actions.

## Changes

- `changeQuoteRequestState` on `QuoteRequestUpdateHandler`, following the same shape as `changeOrderState` on the order handler — a plain assignment, no transition validation, consistent with how the other `change*State` actions behave here.
- A test covering the update through the service endpoint.

`MyQuoteRequestRepository extends QuoteRequestRepository`, so the `/me` path picks this up unchanged.

## Verification

`pnpm tsc`, `pnpm biome check` and `pnpm test` (790 tests) all pass.