### PR TITLE
fix: apply the rest of a predicate after a parenthesized group

### DIFF
--- a/.changeset/predicate-group-parenthesis.md
+++ b/.changeset/predicate-group-parenthesis.md
@@ -1,0 +1,17 @@
+---
+"@labdigital/commercetools-mock": patch
+---
+
+Fix query predicates where a parenthesized group is followed by another clause.
+
+The `(` nud did not consume its closing parenthesis, so the outer parse loop
+stopped on it and everything after the group was silently dropped:
+`(status="OPEN" or status="OVERDUE") and dueDate < "..."` was evaluated as just
+the group, quietly widening a filter that should narrow. The same applied to
+`in (...)`, `contains all/any (...)` and `nested(...)` groups followed by a
+clause.
+
+A predicate that cannot be consumed completely now raises a `PredicateError`
+instead of matching against a partially parsed expression, so an unsupported or
+malformed predicate surfaces at the point of use rather than returning the whole
+collection.

--- a/src/lib/predicateParser.test.ts
+++ b/src/lib/predicateParser.test.ts
@@ -244,9 +244,9 @@ describe("Predicate filter", () => {
 	});
 
 	test("array filters on property", async () => {
-		expect(match(`array(nestedArray(stringProperty="foo")))`)).toBeTruthy();
+		expect(match(`array(nestedArray(stringProperty="foo"))`)).toBeTruthy();
 		expect(
-			match(`array(nestedArray(nested(stringProperty="foo"))))`),
+			match(`array(nestedArray(nested(stringProperty="foo")))`),
 		).toBeTruthy();
 	});
 
@@ -269,9 +269,9 @@ describe("Predicate filter", () => {
 		expect(match("not (numberProperty = 1235)")).toBeTruthy();
 		expect(match("not (numberProperty = 1235)")).toBeTruthy();
 
-		expect(match("nested(numberProperty=1234))")).toBeTruthy();
-		expect(match("nested(not(numberProperty=1230)))")).toBeTruthy();
-		expect(match("nested(not(numberProperty=1234)))")).toBeFalsy();
+		expect(match("nested(numberProperty=1234)")).toBeTruthy();
+		expect(match("nested(not(numberProperty=1230))")).toBeTruthy();
+		expect(match("nested(not(numberProperty=1234))")).toBeFalsy();
 	});
 
 	test("and clause (implicit)", async () => {
@@ -306,6 +306,84 @@ describe("Predicate filter", () => {
 				"numberProperty=1234 and (numberProperty=1230 or (numberProperty=1234 or numberProperty=1235))",
 			),
 		).toBeTruthy();
+	});
+
+	test("group followed by another clause", async () => {
+		expect(
+			match(
+				`(stringProperty="foobar" or stringProperty="nope") and numberProperty=1234`,
+			),
+		).toBeTruthy();
+		expect(
+			match(
+				`(stringProperty="nope" or stringProperty="nope2") and numberProperty=1234`,
+			),
+		).toBeFalsy();
+		expect(
+			match(
+				`(stringProperty="foobar" or stringProperty="nope") and numberProperty=1230`,
+			),
+		).toBeFalsy();
+		expect(
+			match(
+				`(numberProperty=1230) or (numberProperty=1234 and booleanProperty=true)`,
+			),
+		).toBeTruthy();
+		expect(
+			match("not (numberProperty=1230) and booleanProperty=true"),
+		).toBeTruthy();
+		expect(
+			match("not (numberProperty=1234) and booleanProperty=true"),
+		).toBeFalsy();
+	});
+
+	test("in (...) followed by another clause", async () => {
+		expect(
+			match(`stringProperty in ("foobar", "other") and numberProperty=1234`),
+		).toBeTruthy();
+		expect(
+			match(`stringProperty in ("nope", "other") and numberProperty=1234`),
+		).toBeFalsy();
+		expect(
+			match(`stringProperty in ("nope") or numberProperty in (1234)`),
+		).toBeTruthy();
+	});
+
+	test("contains (...) followed by another clause", async () => {
+		expect(
+			match(
+				`arrayProperty contains all ("foo", "bar") and numberProperty=1234`,
+			),
+		).toBeTruthy();
+		expect(
+			match(`arrayProperty contains any ("nope") or numberProperty=1234`),
+		).toBeTruthy();
+		expect(
+			match(`arrayProperty contains any ("nope") and numberProperty=1234`),
+		).toBeFalsy();
+	});
+
+	test("nested group followed by another clause", async () => {
+		expect(
+			match(
+				`nested(objectProperty(stringProperty="foobar")) and numberProperty=1234`,
+			),
+		).toBeTruthy();
+		expect(
+			match(
+				`nested(objectProperty(stringProperty="nope")) and numberProperty=1234`,
+			),
+		).toBeFalsy();
+	});
+
+	test("trailing input is rejected instead of ignored", async () => {
+		expect(() => match(`(numberProperty=1234))`)).toThrow(PredicateError);
+		expect(() => match(`(numberProperty=1234))`)).toThrow(
+			"Invalid input ')' (line 1, column 22)",
+		);
+		expect(() =>
+			match(`stringProperty="foobar" numberProperty=1234`),
+		).toThrow();
 	});
 	test("nested attribute access", async () => {
 		expect(

--- a/src/lib/predicateParser.ts
+++ b/src/lib/predicateParser.ts
@@ -254,6 +254,9 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 		})
 		.nud("(", 100, (t) => {
 			const expr: any = parser.parse({ terminals: [")"] });
+			// Consume the closing parenthesis so a following operator (`and`, `or`)
+			// is still seen by the caller instead of being silently dropped
+			lexer.expect(")");
 			return expr;
 		})
 		.led("(", 100, ({ left, bp }) => {
@@ -381,13 +384,9 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 			}
 		})
 		.led("IN", 20, ({ left, bp }) => {
-			const firstToken = lexer.peek();
+			// IN can be a single value or a list of values; the parenthesized list
+			// is consumed by the `(` nud
 			const expr = parser.parse({ terminals: [bp - 1] });
-
-			// IN can be a single value or a list of values
-			if (firstToken.match === "(") {
-				lexer.expect(")");
-			}
 
 			return (obj: any, vars: object) => {
 				let symbols = expr;
@@ -461,7 +460,7 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 		.led("CONTAINS", 20, ({ left, bp }) => {
 			const keyword = lexer.next();
 
-			let expr = parser.parse();
+			let expr = parser.parse({ terminals: [bp - 1] });
 			if (!Array.isArray(expr)) {
 				expr = [expr];
 			}
@@ -486,6 +485,15 @@ const generateMatchFunc = (predicate: string): MatchFunc => {
 		.build();
 
 	const result = parser.parse();
+
+	// A predicate we cannot fully consume must not silently match everything
+	const remainder = lexer.peek();
+	if (!remainder.isEof()) {
+		const { start } = remainder.strpos();
+		throw new PredicateError(
+			`Invalid input '${remainder.match}' (line ${start.line}, column ${start.column})`,
+		);
+	}
 
 	if (typeof result !== "function") {
 		const lines = predicate.split("\n");

--- a/src/shipping.ts
+++ b/src/shipping.ts
@@ -124,7 +124,7 @@ export const getShippingMethodsMatchingCart = async (
 
 	// Get all shipping methods that have a zone that matches the shipping address
 	const zones = await storage.query<"zone">(context.projectKey, "zone", {
-		where: [`locations(country="${cart.shippingAddress.country}"))`],
+		where: [`locations(country="${cart.shippingAddress.country}")`],
 		limit: 100,
 	});
 	const zoneIds = zones.results.map((zone) => zone.id);


### PR DESCRIPTION
Fixes #416.

## The bug

The `(` nud in `src/lib/predicateParser.ts` parsed its contents with `)` as a *terminal* but never consumed it. Since `)` has binding power 0, the outer parse loop stopped there and the remainder of the predicate was silently dropped:

```
(status = "OPEN" or status = "OVERDUE") and dueDate < "2050-01-01"
```

evaluated as just the group. A filter that should narrow instead widened, and the call succeeded — which, as the issue points out, is worse than an error: a test asserting "the filter returned rows" passes while asserting nothing.

The same shape affected `in (...)`, `contains all/any (...)` and `nested(...)` when followed by another clause.

## The fix

- The `(` nud consumes its closing parenthesis, so a following `and`/`or` is seen by the caller.
- The `IN` led no longer expects the `)` itself — that was compensating for the nud not consuming it.
- `CONTAINS` bounds its operand parse (`terminals: [bp - 1]`) the way `IN` already did, so a following `and`/`or` is not applied to the value list.
- `generateMatchFunc` now throws a `PredicateError` when the lexer is not at EOF after parsing. This is the "fail loudly" part of the issue: a predicate that cannot be fully consumed no longer matches a partially parsed expression.

## Fallout from failing loudly

The EOF check surfaced two malformed predicates that only worked because the tail was ignored:

- `src/shipping.ts` built `locations(country="XX"))` with an extra `)` for the zone lookup.
- Five parser test cases had unbalanced parentheses (`nested(numberProperty=1234))`).

Both are corrected here.

## Coverage

Five new test cases in `predicateParser.test.ts` covering a group, `in (...)`, `contains (...)`, `nested(...)` and `not (...)` followed by another clause, plus one asserting trailing input is rejected. Verified they fail without the fix. Full suite: 795 passing.