### PR TITLE
feat: support addPayment and removePayment on carts

### DIFF
--- a/.changeset/cart-add-payment.md
+++ b/.changeset/cart-add-payment.md
@@ -1,0 +1,12 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Support the `addPayment` and `removePayment` update actions on carts, and
+`removePayment` on orders.
+
+`addPayment` existed only on the order handler, so the payment-first checkout
+flow — attach the payment to the cart, then create the order from the provider
+callback — could not be exercised against the mock. Because carts and `/me`
+carts share a repository, both scopes get the actions. `removePayment` was
+missing on carts and orders alike and is the natural pair.

--- a/src/repositories/cart/actions.ts
+++ b/src/repositories/cart/actions.ts
@@ -6,6 +6,7 @@ import type {
 	CartAddCustomLineItemAction,
 	CartAddItemShippingAddressAction,
 	CartAddLineItemAction,
+	CartAddPaymentAction,
 	CartChangeCustomLineItemMoneyAction,
 	CartChangeCustomLineItemQuantityAction,
 	CartChangeLineItemQuantityAction,
@@ -13,6 +14,7 @@ import type {
 	CartRemoveCustomLineItemAction,
 	CartRemoveDiscountCodeAction,
 	CartRemoveLineItemAction,
+	CartRemovePaymentAction,
 	CartRemoveShippingMethodAction,
 	CartSetAnonymousIdAction,
 	CartSetBillingAddressAction,
@@ -284,6 +286,65 @@ export class CartUpdateHandler
 
 		// Update cart total price
 		resource.totalPrice.centAmount = calculateCartTotalPrice(resource);
+	}
+
+	async addPayment(
+		context: RepositoryContext,
+		resource: Writable<Cart>,
+		{ payment }: CartAddPaymentAction,
+	) {
+		const resolvedPayment = await this._storage.getByResourceIdentifier(
+			context.projectKey,
+			payment,
+		);
+		if (!resolvedPayment) {
+			throw new CommercetoolsError<ReferencedResourceNotFoundError>({
+				code: "ReferencedResourceNotFound",
+				message: `Payment ${payment.id} not found`,
+				typeId: "payment",
+			});
+		}
+
+		if (!resource.paymentInfo) {
+			resource.paymentInfo = {
+				payments: [],
+			};
+		}
+
+		resource.paymentInfo.payments.push({
+			typeId: "payment",
+			id: resolvedPayment.id,
+		});
+	}
+
+	async removePayment(
+		context: RepositoryContext,
+		resource: Writable<Cart>,
+		{ payment }: CartRemovePaymentAction,
+	) {
+		const resolvedPayment = await this._storage.getByResourceIdentifier(
+			context.projectKey,
+			payment,
+		);
+		if (!resolvedPayment) {
+			throw new CommercetoolsError<ReferencedResourceNotFoundError>({
+				code: "ReferencedResourceNotFound",
+				message: `Payment ${payment.id} not found`,
+				typeId: "payment",
+			});
+		}
+
+		if (!resource.paymentInfo) {
+			return;
+		}
+
+		resource.paymentInfo.payments = resource.paymentInfo.payments.filter(
+			(reference) => reference.id !== resolvedPayment.id,
+		);
+
+		if (resource.paymentInfo.payments.length === 0) {
+			resource.paymentInfo = undefined;
+		}
 	}
 
 	changeLineItemQuantity(

--- a/src/repositories/order/actions.ts
+++ b/src/repositories/order/actions.ts
@@ -11,6 +11,7 @@ import type {
 	OrderChangeOrderStateAction,
 	OrderChangePaymentStateAction,
 	OrderChangeShipmentStateAction,
+	OrderRemovePaymentAction,
 	OrderSetBillingAddressAction,
 	OrderSetCustomerEmailAction,
 	OrderSetCustomerIdAction,
@@ -75,6 +76,36 @@ export class OrderUpdateHandler
 			typeId: "payment",
 			id: payment.id!,
 		});
+	}
+
+	async removePayment(
+		context: RepositoryContext,
+		resource: Writable<Order>,
+		{ payment }: OrderRemovePaymentAction,
+	) {
+		const resolvedPayment = await this._storage.getByResourceIdentifier(
+			context.projectKey,
+			payment,
+		);
+		if (!resolvedPayment) {
+			throw new CommercetoolsError<ReferencedResourceNotFoundError>({
+				code: "ReferencedResourceNotFound",
+				message: `Payment ${payment.id} not found`,
+				typeId: "payment",
+			});
+		}
+
+		if (!resource.paymentInfo) {
+			return;
+		}
+
+		resource.paymentInfo.payments = resource.paymentInfo.payments.filter(
+			(reference) => reference.id !== resolvedPayment.id,
+		);
+
+		if (resource.paymentInfo.payments.length === 0) {
+			resource.paymentInfo = undefined;
+		}
 	}
 
 	async addReturnInfo(

--- a/src/services/cart.test.ts
+++ b/src/services/cart.test.ts
@@ -13,6 +13,7 @@ import { calculateMoneyTotalCentAmount } from "#src/repositories/helpers.ts";
 import {
 	cartDraftFactory,
 	customerDraftFactory,
+	paymentDraftFactory,
 	productDraftFactory,
 	productTypeDraftFactory,
 	shippingMethodDraftFactory,
@@ -130,6 +131,7 @@ describe("Cart Update Actions", () => {
 	const typeFactory = typeDraftFactory(ctMock);
 	const zoneFactory = zoneDraftFactory(ctMock);
 	const shippingMethodFactory = shippingMethodDraftFactory(ctMock);
+	const paymentFactory = paymentDraftFactory(ctMock);
 
 	beforeEach(async () => {
 		const productType = await productTypeDraftFactory(ctMock).create({
@@ -294,6 +296,93 @@ describe("Cart Update Actions", () => {
 		expect(response.json().version).toBe(2);
 		expect(response.json().lineItems).toHaveLength(1);
 		expect(response.json().totalPrice.centAmount).toEqual(29800);
+	});
+
+	test("addPayment", async () => {
+		const payment = await paymentFactory.create({
+			amountPlanned: { currencyCode: "EUR", centAmount: 14900 },
+		});
+
+		assert(cart, "cart not created");
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/carts/${cart.id}`,
+			payload: {
+				version: 1,
+				actions: [
+					{
+						action: "addPayment",
+						payment: { typeId: "payment", id: payment.id },
+					},
+				],
+			},
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json().version).toBe(2);
+		expect(response.json().paymentInfo).toEqual({
+			payments: [{ typeId: "payment", id: payment.id }],
+		});
+	});
+
+	test("addPayment with an unknown payment", async () => {
+		assert(cart, "cart not created");
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/carts/${cart.id}`,
+			payload: {
+				version: 1,
+				actions: [
+					{
+						action: "addPayment",
+						payment: { typeId: "payment", id: "does-not-exist" },
+					},
+				],
+			},
+		});
+		expect(response.statusCode).toBe(400);
+		expect(response.json().errors[0].code).toBe("ReferencedResourceNotFound");
+	});
+
+	test("removePayment", async () => {
+		const payment = await paymentFactory.create({
+			amountPlanned: { currencyCode: "EUR", centAmount: 14900 },
+		});
+
+		assert(cart, "cart not created");
+
+		const added = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/carts/${cart.id}`,
+			payload: {
+				version: 1,
+				actions: [
+					{
+						action: "addPayment",
+						payment: { typeId: "payment", id: payment.id },
+					},
+				],
+			},
+		});
+		expect(added.statusCode).toBe(200);
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/carts/${cart.id}`,
+			payload: {
+				version: 2,
+				actions: [
+					{
+						action: "removePayment",
+						payment: { typeId: "payment", id: payment.id },
+					},
+				],
+			},
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json().version).toBe(3);
+		expect(response.json().paymentInfo).toBeUndefined();
 	});
 
 	test.each([

--- a/src/services/order.test.ts
+++ b/src/services/order.test.ts
@@ -19,6 +19,7 @@ import {
 	cartDraftFactory,
 	channelDraftFactory,
 	orderDraftFactory,
+	paymentDraftFactory,
 	typeDraftFactory,
 } from "#src/testing/index.ts";
 import { CommercetoolsMock, getBaseResourceProperties } from "../index.ts";
@@ -368,6 +369,49 @@ describe("Order Update Actions", () => {
 		expect(responseAgain.statusCode).toBe(200);
 		expect(responseAgain.json().version).toBe(2);
 		expect(responseAgain.json().locale).toBe("nl-NL");
+	});
+
+	test("addPayment and removePayment", async () => {
+		assert(order, "order not created");
+
+		const payment = await paymentDraftFactory(ctMock).create({
+			amountPlanned: { currencyCode: "EUR", centAmount: 1000 },
+		});
+
+		const added = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/orders/${order.id}`,
+			payload: {
+				version: 1,
+				actions: [
+					{
+						action: "addPayment",
+						payment: { typeId: "payment", id: payment.id },
+					},
+				],
+			},
+		});
+		expect(added.statusCode).toBe(200);
+		expect(added.json().paymentInfo).toEqual({
+			payments: [{ typeId: "payment", id: payment.id }],
+		});
+
+		const removed = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/orders/${order.id}`,
+			payload: {
+				version: 2,
+				actions: [
+					{
+						action: "removePayment",
+						payment: { typeId: "payment", id: payment.id },
+					},
+				],
+			},
+		});
+		expect(removed.statusCode).toBe(200);
+		expect(removed.json().version).toBe(3);
+		expect(removed.json().paymentInfo).toBeUndefined();
 	});
 
 	test("setCustomerEmail", async () => {


### PR DESCRIPTION
Fixes #415.

`addPayment` was implemented on `OrderUpdateHandler` but had no counterpart on `CartUpdateHandler`, so a cart update carrying it failed with `Invalid action addPayment`.

## What this adds

- `addPayment` on carts — resolves the payment reference, throws `ReferencedResourceNotFound` (400) if it does not exist, seeds `paymentInfo` and pushes the reference. Mirrors the order implementation.
- `removePayment` on carts and on orders. It was missing on both; `paymentInfo` is dropped entirely once the last payment is removed, so a cart that had its payment removed looks like one that never had a payment.

`/me` carts go through the same `CartRepository`, so `MyCartAddPaymentAction` and `MyCartRemovePaymentAction` are covered by the same change.

## Coverage

- `cart.test.ts`: attach a payment, attach an unknown payment (400 `ReferencedResourceNotFound`), remove a payment.
- `order.test.ts`: attach then remove, asserting `paymentInfo` disappears.

Full suite: 794 passing.

Note: `freezeCart`/`unfreezeCart` from #414 is the other half of the flow described in the issue and is handled in a separate PR.