### PR TITLE
feat: add as-associate quote routes

### DIFF
--- a/.changeset/as-associate-quotes.md
+++ b/.changeset/as-associate-quotes.md
@@ -1,0 +1,12 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Add the associate-scoped quote routes.
+
+The associate scope covered quote requests but not quotes, so any
+`.asAssociate().…​.quotes()` read returned a 404 and the correct way to read a
+colleague's quote was the one path that could not be tested. The service
+registers what commercetools documents for associate quotes — query, get by id,
+get by key, update by id and update by key — and no create or delete route,
+since quotes are created by the seller.

--- a/src/repositories/as-associate.ts
+++ b/src/repositories/as-associate.ts
@@ -3,11 +3,13 @@ import { ApprovalRuleRepository } from "./approval-rule.ts";
 import { BusinessUnitRepository } from "./business-unit.ts";
 import { CartRepository } from "./cart/index.ts";
 import { OrderRepository } from "./order/index.ts";
+import { QuoteRepository } from "./quote/index.ts";
 import { QuoteRequestRepository } from "./quote-request/index.ts";
 import { ShoppingListRepository } from "./shopping-list/index.ts";
 
 export class AsAssociateOrderRepository extends OrderRepository {}
 export class AsAssociateCartRepository extends CartRepository {}
+export class AsAssociateQuoteRepository extends QuoteRepository {}
 export class AsAssociateQuoteRequestRepository extends QuoteRequestRepository {}
 export class AsAssociateShoppingListRepository extends ShoppingListRepository {}
 export class AsAssociateBusinessUnitRepository extends BusinessUnitRepository {}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -8,6 +8,7 @@ import {
 	AsAssociateBusinessUnitRepository,
 	AsAssociateCartRepository,
 	AsAssociateOrderRepository,
+	AsAssociateQuoteRepository,
 	AsAssociateQuoteRequestRepository,
 	AsAssociateShoppingListRepository,
 } from "./as-associate.ts";
@@ -61,6 +62,7 @@ export const createRepositories = (config: Config) => ({
 		"business-unit": new AsAssociateBusinessUnitRepository(config),
 		cart: new AsAssociateCartRepository(config),
 		order: new AsAssociateOrderRepository(config),
+		quote: new AsAssociateQuoteRepository(config),
 		"quote-request": new AsAssociateQuoteRequestRepository(config),
 		"shopping-list": new AsAssociateShoppingListRepository(config),
 	},

--- a/src/services/as-associate-quote.test.ts
+++ b/src/services/as-associate-quote.test.ts
@@ -1,0 +1,125 @@
+import type { Quote } from "@commercetools/platform-sdk";
+import { afterEach, describe, expect, test } from "vitest";
+import { typeDraftFactory } from "#src/testing/index.ts";
+import { CommercetoolsMock, getBaseResourceProperties } from "../index.ts";
+
+const ctMock = new CommercetoolsMock({ defaultProjectKey: "dummy" });
+const projectKey = "dummy";
+const associateId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
+const businessUnitKey = "test-business-unit";
+const basePath = `/${projectKey}/as-associate/${associateId}/in-business-unit/key=${businessUnitKey}/quotes`;
+
+const createQuote = async () => {
+	const quote: Quote = {
+		...getBaseResourceProperties(),
+		key: "quote-1",
+		quoteState: "Pending",
+		customer: {
+			typeId: "customer",
+			id: "8d4d2b1a-6d90-4f0f-9e34-3c1a01e6b3f1",
+		},
+		quoteRequest: {
+			typeId: "quote-request",
+			id: "0f0f0a3b-6a2f-4a4c-9a05-6a6b0a5f7d3e",
+		},
+		stagedQuote: {
+			typeId: "staged-quote",
+			id: "1ac6f1a0-6f4b-4a8e-9f9e-2ac4f6a1b7c2",
+		},
+		lineItems: [],
+		customLineItems: [],
+		taxMode: "Platform",
+		priceRoundingMode: "HalfEven",
+		taxRoundingMode: "HalfEven",
+		taxCalculationMode: "LineItemLevel",
+		totalPrice: {
+			type: "centPrecision",
+			currencyCode: "EUR",
+			centAmount: 1000,
+			fractionDigits: 2,
+		},
+	};
+
+	await ctMock.project().unsafeAdd("quote", quote);
+	return quote;
+};
+
+describe("AsAssociate quotes", () => {
+	afterEach(() => {
+		ctMock.clear();
+	});
+
+	test("query quotes", async () => {
+		const quote = await createQuote();
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: basePath,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].id).toBe(quote.id);
+	});
+
+	test("get quote by id", async () => {
+		const quote = await createQuote();
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${basePath}/${quote.id}`,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().id).toBe(quote.id);
+	});
+
+	test("get quote by key", async () => {
+		const quote = await createQuote();
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${basePath}/key=${quote.key}`,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().id).toBe(quote.id);
+	});
+
+	test("get unknown quote", async () => {
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${basePath}/2c4bb2c1-0f4f-4c1e-9d2f-9a1d3e4b5c6a`,
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test("update quote by id", async () => {
+		const quote = await createQuote();
+		const type = await typeDraftFactory(ctMock).create({
+			key: "quote-type",
+			name: { en: "quote-type" },
+			resourceTypeIds: ["quote"],
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `${basePath}/${quote.id}`,
+			payload: {
+				version: quote.version,
+				actions: [
+					{
+						action: "setCustomType",
+						type: { typeId: "type", id: type.id },
+						fields: { foo: "bar" },
+					},
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().version).toBe(quote.version + 1);
+		expect(response.json().custom.fields).toEqual({ foo: "bar" });
+	});
+});

--- a/src/services/as-associate-quote.ts
+++ b/src/services/as-associate-quote.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from "fastify";
+import type { AsAssociateQuoteRepository } from "#src/repositories/as-associate.ts";
+import AbstractService from "./abstract.ts";
+
+export class AsAssociateQuoteService extends AbstractService {
+	public repository: AsAssociateQuoteRepository;
+
+	constructor(parent: FastifyInstance, repository: AsAssociateQuoteRepository) {
+		super(parent);
+		this.repository = repository;
+	}
+
+	getBasePath() {
+		return "quotes";
+	}
+
+	registerRoutes(parent: FastifyInstance) {
+		const basePath = this.getBasePath();
+		parent.register(
+			(instance, opts, done) => {
+				this.extraRoutes(instance);
+
+				instance.get("/", this.get.bind(this));
+				instance.get("/key=:key", this.getWithKey.bind(this));
+				instance.get("/:id", this.getWithId.bind(this));
+
+				// An associate reads and updates quotes; quotes are created by the
+				// seller, so the associate scope has no create or delete route
+				instance.post("/key=:key", this.postWithKey.bind(this));
+				instance.post("/:id", this.postWithId.bind(this));
+
+				done();
+			},
+			{ prefix: `/${basePath}` },
+		);
+	}
+}

--- a/src/services/as-associate.ts
+++ b/src/services/as-associate.ts
@@ -5,6 +5,7 @@ import type {
 	AsAssociateBusinessUnitRepository,
 	AsAssociateCartRepository,
 	AsAssociateOrderRepository,
+	AsAssociateQuoteRepository,
 	AsAssociateQuoteRequestRepository,
 	AsAssociateShoppingListRepository,
 } from "#src/repositories/as-associate.ts";
@@ -13,6 +14,7 @@ import { AsAssociateApprovalRuleService } from "./as-associate-approval-rule.ts"
 import { AsAssociateBusinessUnitService } from "./as-associate-business-unit.ts";
 import { AsAssociateCartService } from "./as-associate-cart.ts";
 import { AsAssociateOrderService } from "./as-associate-order.ts";
+import { AsAssociateQuoteService } from "./as-associate-quote.ts";
 import { AsAssociateQuoteRequestService } from "./as-associate-quote-request.ts";
 import { AsAssociateShoppingListService } from "./as-associate-shopping-list.ts";
 
@@ -22,6 +24,7 @@ type Repositories = {
 	"business-unit": AsAssociateBusinessUnitRepository;
 	cart: AsAssociateCartRepository;
 	order: AsAssociateOrderRepository;
+	quote: AsAssociateQuoteRepository;
 	"quote-request": AsAssociateQuoteRequestRepository;
 	"shopping-list": AsAssociateShoppingListRepository;
 };
@@ -33,6 +36,7 @@ export class AsAssociateService {
 		"business-unit": AsAssociateBusinessUnitService;
 		cart: AsAssociateCartService;
 		order: AsAssociateOrderService;
+		quote: AsAssociateQuoteService;
 		"quote-request": AsAssociateQuoteRequestService;
 		"shopping-list": AsAssociateShoppingListService;
 	};
@@ -52,6 +56,10 @@ export class AsAssociateService {
 							repositories.order,
 						);
 						const cart = new AsAssociateCartService(scoped, repositories.cart);
+						const quote = new AsAssociateQuoteService(
+							scoped,
+							repositories.quote,
+						);
 						const quoteRequest = new AsAssociateQuoteRequestService(
 							scoped,
 							repositories["quote-request"],
@@ -75,6 +83,7 @@ export class AsAssociateService {
 							"business-unit": businessUnitService,
 							order,
 							cart,
+							quote,
 							"quote-request": quoteRequest,
 							"shopping-list": shoppingList,
 						};


### PR DESCRIPTION
Fixes #413.

The associate-scoped routes covered quote **requests** but not quotes, so `.asAssociate().…​.quotes().withId(…).get()` returned 404.

## What this adds

`AsAssociateQuoteService` + `AsAssociateQuoteRepository`, wired into the existing `as-associate` service and repository maps next to `quote-request`.

Routes registered are exactly the ones [commercetools documents for associate quotes](https://docs.commercetools.com/api/projects/associate-quotes):

- `GET .../quotes`
- `GET .../quotes/{id}`
- `GET .../quotes/key={key}`
- `POST .../quotes/{id}`
- `POST .../quotes/key={key}`

No create and no delete route — quotes are created by the seller from a staged quote, so the associate scope has neither. That is why the service overrides `registerRoutes` instead of inheriting the default set, and why it does not simply mirror `AsAssociateQuoteRequestService` (which does have create/delete, correctly).

## Not in scope

Permission checking — an associate can still read any quote in the mock, as with the other associate resources. That is the remaining part of #258.

## Coverage

`as-associate-quote.test.ts`: query, get by id, get by key, unknown id (404), and an update by id that applies `setCustomType`.

Full suite: 795 passing.