### PR TITLE
feat: model purchaseOrderNumber on carts

### DIFF
--- a/.changeset/cart-purchase-order-number.md
+++ b/.changeset/cart-purchase-order-number.md
@@ -1,0 +1,12 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Model `purchaseOrderNumber` on carts: store it from `CartDraft` and support the
+`setPurchaseOrderNumber` update action.
+
+B2B checkout captures the buyer's purchase order number on the cart before the
+order exists, but the mock dropped the draft field and rejected the action, so
+that write path had no coverage available. The cart's `purchaseOrderNumber` now
+also carries through to an order created from it, the way it does on
+commercetools.

--- a/src/repositories/cart/actions.ts
+++ b/src/repositories/cart/actions.ts
@@ -37,6 +37,7 @@ import type {
 	CartSetLineItemTaxAmountAction,
 	CartSetLineItemTaxRateAction,
 	CartSetLocaleAction,
+	CartSetPurchaseOrderNumberAction,
 	CartSetShippingAddressAction,
 	CartSetShippingAddressCustomFieldAction,
 	CartSetShippingAddressCustomTypeAction,
@@ -1118,6 +1119,14 @@ export class CartUpdateHandler
 			...shippingDetails,
 			valid: true,
 		} as ItemShippingDetails;
+	}
+
+	setPurchaseOrderNumber(
+		_context: RepositoryContext,
+		resource: Writable<Cart>,
+		{ purchaseOrderNumber }: CartSetPurchaseOrderNumberAction,
+	) {
+		resource.purchaseOrderNumber = purchaseOrderNumber;
 	}
 
 	setLocale(

--- a/src/repositories/cart/index.ts
+++ b/src/repositories/cart/index.ts
@@ -176,6 +176,7 @@ export class CartRepository extends AbstractResourceRepository<"cart"> {
 			shipping: [],
 			shippingInfo: undefined,
 			origin: draft.origin ?? "Customer",
+			purchaseOrderNumber: draft.purchaseOrderNumber,
 			refusedGifts: [],
 			custom: await createCustomFields(
 				draft.custom,

--- a/src/repositories/order/index.ts
+++ b/src/repositories/order/index.ts
@@ -122,6 +122,7 @@ export class OrderRepository extends AbstractResourceRepository<"order"> {
 			orderState: "Open",
 			origin: "Customer",
 			paymentInfo: cart.paymentInfo,
+			purchaseOrderNumber: cart.purchaseOrderNumber,
 			refusedGifts: [],
 			shipping: cart.shipping,
 			shippingAddress: cart.shippingAddress,

--- a/src/services/cart.test.ts
+++ b/src/services/cart.test.ts
@@ -536,6 +536,56 @@ describe("Cart Update Actions", () => {
 		expect(response.json().lineItems).toHaveLength(1);
 	});
 
+	test("setPurchaseOrderNumber", async () => {
+		assert(cart, "cart not created");
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/carts/${cart.id}`,
+			payload: {
+				version: 1,
+				actions: [
+					{ action: "setPurchaseOrderNumber", purchaseOrderNumber: "PO-4711" },
+				],
+			},
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json().version).toBe(2);
+		expect(response.json().purchaseOrderNumber).toBe("PO-4711");
+
+		const unset = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/carts/${cart.id}`,
+			payload: {
+				version: 2,
+				actions: [{ action: "setPurchaseOrderNumber" }],
+			},
+		});
+		expect(unset.statusCode).toBe(200);
+		expect(unset.json().purchaseOrderNumber).toBeUndefined();
+	});
+
+	test("purchaseOrderNumber from the draft carries through to the order", async () => {
+		const created = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/carts",
+			payload: { currency: "EUR", purchaseOrderNumber: "PO-4711" },
+		});
+		expect(created.statusCode).toBe(201);
+		expect(created.json().purchaseOrderNumber).toBe("PO-4711");
+
+		const order = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/orders",
+			payload: {
+				cart: { typeId: "cart", id: created.json().id },
+				version: created.json().version,
+			},
+		});
+		expect(order.statusCode).toBe(201);
+		expect(order.json().purchaseOrderNumber).toBe("PO-4711");
+	});
+
 	test.each([
 		["EUR", 29800],
 		["GBP", 37800],


### PR DESCRIPTION
Fixes #411.

Three small pieces:

1. `CartDraft.purchaseOrderNumber` is stored on create — it was dropped, so a cart created with one read back without it.
2. `setPurchaseOrderNumber` is implemented on `CartUpdateHandler`; omitting `purchaseOrderNumber` unsets it, matching the action's optional field.
3. An order created from a cart carries the cart's `purchaseOrderNumber`. That is the point of capturing it on the cart, and `createFromCart` was not copying it.

`CartSetPurchaseOrderNumberAction` exists only on the full and associate-scoped cart endpoints. The associate scope shares `CartRepository`, so it needs no separate handler; `/me` carts share it too, so the action is reachable there as well even though `MyCartSetPurchaseOrderNumberAction` does not exist — the mock does not filter actions per scope for any resource today, so this PR does not introduce that.

## Coverage

`cart.test.ts`: set then unset the number, and a draft-created cart whose number survives into the order created from it.

Full suite: 792 passing.