### PR TITLE
feat: support addParcelToDelivery on orders

### DIFF
--- a/.changeset/order-add-parcel-to-delivery.md
+++ b/.changeset/order-add-parcel-to-delivery.md
@@ -1,0 +1,10 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Support the `addParcelToDelivery` update action on orders.
+
+Parcels could only be supplied inline through `addDelivery`, so adding one to a
+delivery that already exists — which is what happens when a shipment is handed
+over in parts — had no route. The action accepts either `deliveryId` or
+`deliveryKey`, and rejects an unknown delivery instead of quietly doing nothing.

--- a/src/repositories/order/actions.ts
+++ b/src/repositories/order/actions.ts
@@ -6,6 +6,7 @@ import type {
 	LineItemReturnItem,
 	Order,
 	OrderAddDeliveryAction,
+	OrderAddParcelToDeliveryAction,
 	OrderAddPaymentAction,
 	OrderAddReturnInfoAction,
 	OrderChangeOrderStateAction,
@@ -246,6 +247,56 @@ export class OrderUpdateHandler
 		};
 
 		resource.shippingInfo.deliveries.push(delivery);
+	}
+
+	async addParcelToDelivery(
+		context: RepositoryContext,
+		resource: Writable<Order>,
+		{ deliveryId, deliveryKey, ...parcelDraft }: OrderAddParcelToDeliveryAction,
+	) {
+		if (!resource.shippingInfo) {
+			throw new CommercetoolsError<InvalidOperationError>({
+				code: "InvalidOperation",
+				message: "Resource has no shipping info",
+			});
+		}
+
+		if (!deliveryId && !deliveryKey) {
+			throw new CommercetoolsError<RequiredFieldError>({
+				code: "RequiredField",
+				message: "Either deliveryId or deliveryKey is required",
+				field: "deliveryId",
+			});
+		}
+
+		const delivery = resource.shippingInfo.deliveries?.find((d) =>
+			deliveryId ? d.id === deliveryId : d.key === deliveryKey,
+		) as Writable<Delivery> | undefined;
+
+		if (!delivery) {
+			throw new CommercetoolsError<InvalidOperationError>({
+				code: "InvalidOperation",
+				message: `A delivery with ${
+					deliveryId ? `ID '${deliveryId}'` : `key '${deliveryKey}'`
+				} was not found on this order.`,
+			});
+		}
+
+		const { parcelKey, ...parcel } = parcelDraft;
+		if (!delivery.parcels) {
+			delivery.parcels = [];
+		}
+
+		delivery.parcels.push({
+			...getBaseResourceProperties(),
+			...parcel,
+			key: parcelKey,
+			custom: await createCustomFields(
+				parcel.custom,
+				context.projectKey,
+				this._storage,
+			),
+		});
 	}
 
 	setDeliveryCustomField(

--- a/src/services/order.test.ts
+++ b/src/services/order.test.ts
@@ -1404,9 +1404,7 @@ describe("Order addParcelToDelivery", () => {
 			url: `/dummy/orders/${order.id}`,
 			payload: {
 				version: order.version,
-				actions: [
-					{ action: "addParcelToDelivery", deliveryKey: "delivery-1" },
-				],
+				actions: [{ action: "addParcelToDelivery", deliveryKey: "delivery-1" }],
 			},
 		});
 

--- a/src/services/order.test.ts
+++ b/src/services/order.test.ts
@@ -1300,6 +1300,155 @@ describe("Order Update Actions", () => {
 	});
 });
 
+describe("Order addParcelToDelivery", () => {
+	const ctMock = new CommercetoolsMock({ defaultProjectKey: "dummy" });
+
+	const buildOrder = (): Order => ({
+		...getBaseResourceProperties(),
+		customLineItems: [],
+		lineItems: [],
+		lastMessageSequenceNumber: 0,
+		orderNumber: generateRandomString(10),
+		orderState: "Open",
+		origin: "Customer",
+		refusedGifts: [],
+		shipping: [],
+		shippingMode: "Single",
+		syncInfo: [],
+		totalPrice: {
+			type: "centPrecision",
+			fractionDigits: 2,
+			centAmount: 2000,
+			currencyCode: "EUR",
+		},
+		shippingInfo: {
+			shippingMethodName: "Home delivery",
+			price: {
+				type: "centPrecision",
+				currencyCode: "EUR",
+				centAmount: 999,
+				fractionDigits: 2,
+			},
+			shippingRate: {
+				price: {
+					type: "centPrecision",
+					currencyCode: "EUR",
+					centAmount: 999,
+					fractionDigits: 2,
+				},
+				tiers: [],
+			},
+			shippingMethodState: "MatchesCart",
+			deliveries: [
+				{
+					id: "6a458cad-dd46-4f5f-8b73-deb0ede6a17d",
+					key: "delivery-1",
+					createdAt: "2024-07-29T13:37:48.047Z",
+					items: [],
+					parcels: [],
+				},
+			],
+		},
+	});
+
+	afterEach(() => {
+		ctMock.clear();
+	});
+
+	const addOrder = async () => {
+		const order = buildOrder();
+		await ctMock.project().unsafeAdd("order", order);
+		return order;
+	};
+
+	test("add a parcel by delivery id", async () => {
+		const order = await addOrder();
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/orders/${order.id}`,
+			payload: {
+				version: order.version,
+				actions: [
+					{
+						action: "addParcelToDelivery",
+						deliveryId: "6a458cad-dd46-4f5f-8b73-deb0ede6a17d",
+						parcelKey: "parcel-1",
+						measurements: {
+							heightInMillimeter: 100,
+							lengthInMillimeter: 200,
+							widthInMillimeter: 300,
+							weightInGram: 400,
+						},
+						trackingData: { trackingId: "1Z999", isReturn: false },
+					},
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+
+		const parcels = response.json().shippingInfo.deliveries[0].parcels;
+		expect(parcels).toHaveLength(1);
+		expect(parcels[0].id).toBeDefined();
+		expect(parcels[0].key).toBe("parcel-1");
+		expect(parcels[0].measurements.weightInGram).toBe(400);
+		expect(parcels[0].trackingData.trackingId).toBe("1Z999");
+	});
+
+	test("add a parcel by delivery key", async () => {
+		const order = await addOrder();
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/orders/${order.id}`,
+			payload: {
+				version: order.version,
+				actions: [
+					{ action: "addParcelToDelivery", deliveryKey: "delivery-1" },
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().shippingInfo.deliveries[0].parcels).toHaveLength(1);
+	});
+
+	test("add a parcel to an unknown delivery", async () => {
+		const order = await addOrder();
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/orders/${order.id}`,
+			payload: {
+				version: order.version,
+				actions: [
+					{ action: "addParcelToDelivery", deliveryKey: "does-not-exist" },
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().errors[0].code).toBe("InvalidOperation");
+	});
+
+	test("add a parcel without a delivery reference", async () => {
+		const order = await addOrder();
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/orders/${order.id}`,
+			payload: {
+				version: order.version,
+				actions: [{ action: "addParcelToDelivery" }],
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().errors[0].code).toBe("RequiredField");
+	});
+});
+
 describe("Order Import", () => {
 	const ctMock = new CommercetoolsMock();
 


### PR DESCRIPTION
Fixes #284.

`addParcelToDelivery` was missing from the order update handler; parcels could only be supplied inline through `addDelivery` when the delivery was first created.

## Behaviour

- Resolves the delivery by `deliveryId` or `deliveryKey`.
- `RequiredField` (400) when neither is given, `InvalidOperation` (400) when no delivery matches — rather than silently doing nothing, which would look like a successful update.
- `InvalidOperation` when the order has no `shippingInfo`, consistent with `addDelivery` and `setParcelCustomField`.
- The parcel gets a generated `id`/`createdAt`, and `parcelKey` from the action is stored as the parcel's `key`, matching how commercetools names it.

## Coverage

`order.test.ts`: add by delivery id (asserting `key`, `measurements` and `trackingData` round-trip), add by delivery key, unknown delivery, and no delivery reference.

Full suite: 794 passing.