### PR TITLE
feat: map the remaining PriceDraft fields

### DIFF
--- a/.changeset/price-from-draft-fields.md
+++ b/.changeset/price-from-draft-fields.md
@@ -1,0 +1,13 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Map the remaining `PriceDraft` fields when creating prices.
+
+`priceFromDraft` only carried `key`, `country`, `value` and `channel`, so
+`customerGroup`, `validFrom`, `validUntil`, `discounted`, `tiers`, `custom` and
+`recurrencePolicy` were silently dropped — a price created with a customer group
+read back without one, which makes customer-group price selection untestable.
+
+The order import used a second, even smaller mapping (`createPrice`, which kept
+only the value). Both paths now go through `priceFromDraft`.

--- a/src/repositories/helpers.ts
+++ b/src/repositories/helpers.ts
@@ -18,8 +18,6 @@ import type {
 	HighPrecisionMoneyDraft,
 	InvalidInputError,
 	InvalidJsonInputError,
-	Price,
-	PriceDraft,
 	Reference,
 	ReferencedResourceNotFoundError,
 	ResourceIdentifier,
@@ -33,7 +31,6 @@ import type {
 } from "@commercetools/platform-sdk";
 import { Decimal } from "decimal.js/decimal";
 import type { FastifyRequest } from "fastify";
-import { v4 as uuidv4 } from "uuid";
 import { CommercetoolsError } from "#src/exceptions.ts";
 import type { AbstractStorage } from "../storage/index.ts";
 import type { RepositoryContext } from "./abstract.ts";
@@ -98,11 +95,6 @@ export const createCustomFields = async (
 		fields: draft.fields ?? {},
 	};
 };
-
-export const createPrice = (draft: PriceDraft): Price => ({
-	id: uuidv4(),
-	value: createTypedMoney(draft.value),
-});
 
 /**
  * Rounds a decimal to the nearest whole number using the specified

--- a/src/repositories/order/index.ts
+++ b/src/repositories/order/index.ts
@@ -47,10 +47,10 @@ import {
 	createAddress,
 	createCentPrecisionMoney,
 	createCustomFields,
-	createPrice,
 	createTypedMoney,
 	resolveStoreReference,
 } from "../helpers.ts";
+import { priceFromDraft } from "../product/helpers.ts";
 import { OrderUpdateHandler } from "./actions.ts";
 
 export class OrderRepository extends AbstractResourceRepository<"order"> {
@@ -290,7 +290,7 @@ export class OrderRepository extends AbstractResourceRepository<"order"> {
 			discountedPricePerQuantity: [],
 			lineItemMode: "Standard",
 			name: draft.name,
-			price: createPrice(draft.price),
+			price: await priceFromDraft(context, this._storage, draft.price),
 			priceMode: "Platform",
 			productId: product.id,
 			productType: product.productType,
@@ -308,7 +308,7 @@ export class OrderRepository extends AbstractResourceRepository<"order"> {
 			variant: {
 				id: variant.id,
 				sku: variant.sku,
-				price: createPrice(draft.price),
+				price: await priceFromDraft(context, this._storage, draft.price),
 				attributes: variant.attributes,
 			},
 		} satisfies LineItem;

--- a/src/repositories/product/helpers.test.ts
+++ b/src/repositories/product/helpers.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+import { getBaseResourceProperties } from "#src/helpers.ts";
+import { InMemoryStorage } from "#src/storage/index.ts";
+import { priceFromDraft } from "./helpers.ts";
+
+describe("priceFromDraft", () => {
+	const storage = new InMemoryStorage();
+	const context = { projectKey: "dummy" };
+
+	const seed = async () => {
+		const customerGroup = await storage.add("dummy", "customer-group", {
+			...getBaseResourceProperties(),
+			key: "vip",
+			name: "VIP",
+		});
+		const channel = await storage.add("dummy", "channel", {
+			...getBaseResourceProperties(),
+			key: "store-1",
+			roles: ["ProductDistribution"],
+		});
+		const type = await storage.add("dummy", "type", {
+			...getBaseResourceProperties(),
+			key: "price-type",
+			name: { en: "price-type" },
+			resourceTypeIds: ["product-price"],
+			fieldDefinitions: [],
+		});
+		return { customerGroup, channel, type };
+	};
+
+	test("maps every field of the draft", async () => {
+		const { customerGroup, channel, type } = await seed();
+
+		const price = await priceFromDraft(context, storage, {
+			key: "base_price_eur",
+			country: "NL",
+			value: { currencyCode: "EUR", centAmount: 1000 },
+			customerGroup: { typeId: "customer-group", key: "vip" },
+			channel: { typeId: "channel", key: "store-1" },
+			validFrom: "2024-01-01T00:00:00.000Z",
+			validUntil: "2024-12-31T00:00:00.000Z",
+			discounted: {
+				value: { currencyCode: "EUR", centAmount: 800 },
+				discount: {
+					typeId: "product-discount",
+					id: "6f0d1e2a-3b4c-4d5e-8f90-1a2b3c4d5e6f",
+				},
+			},
+			tiers: [
+				{
+					minimumQuantity: 10,
+					value: { currencyCode: "EUR", centAmount: 900 },
+				},
+			],
+			custom: {
+				type: { typeId: "type", id: type.id },
+				fields: { foo: "bar" },
+			},
+		});
+
+		expect(price).toEqual({
+			id: expect.any(String),
+			key: "base_price_eur",
+			country: "NL",
+			value: {
+				type: "centPrecision",
+				currencyCode: "EUR",
+				centAmount: 1000,
+				fractionDigits: 2,
+			},
+			customerGroup: { typeId: "customer-group", id: customerGroup.id },
+			channel: { typeId: "channel", id: channel.id },
+			recurrencePolicy: undefined,
+			validFrom: "2024-01-01T00:00:00.000Z",
+			validUntil: "2024-12-31T00:00:00.000Z",
+			discounted: {
+				value: {
+					type: "centPrecision",
+					currencyCode: "EUR",
+					centAmount: 800,
+					fractionDigits: 2,
+				},
+				discount: {
+					typeId: "product-discount",
+					id: "6f0d1e2a-3b4c-4d5e-8f90-1a2b3c4d5e6f",
+				},
+			},
+			tiers: [
+				{
+					minimumQuantity: 10,
+					value: {
+						type: "centPrecision",
+						currencyCode: "EUR",
+						centAmount: 900,
+						fractionDigits: 2,
+					},
+				},
+			],
+			custom: {
+				type: { typeId: "type", id: type.id },
+				fields: { foo: "bar" },
+			},
+		});
+	});
+
+	test("leaves out what the draft does not set", async () => {
+		const price = await priceFromDraft(context, storage, {
+			value: { currencyCode: "EUR", centAmount: 1000 },
+		});
+
+		expect(price.customerGroup).toBeUndefined();
+		expect(price.channel).toBeUndefined();
+		expect(price.discounted).toBeUndefined();
+		expect(price.tiers).toBeUndefined();
+		expect(price.custom).toBeUndefined();
+	});
+});

--- a/src/repositories/product/helpers.ts
+++ b/src/repositories/product/helpers.ts
@@ -3,12 +3,14 @@ import type {
 	Asset,
 	AssetDraft,
 	ChannelReference,
+	CustomerGroupReference,
 	Price,
 	PriceDraft,
 	Product,
 	ProductData,
 	ProductVariant,
 	ProductVariantDraft,
+	RecurrencePolicyReference,
 } from "@commercetools/platform-sdk";
 import { v4 as uuidv4 } from "uuid";
 import type { AbstractStorage } from "#src/storage/index.ts";
@@ -126,4 +128,31 @@ export const priceFromDraft = async (
 				storage,
 			)
 		: undefined,
+	customerGroup: draft.customerGroup
+		? await getReferenceFromResourceIdentifier<CustomerGroupReference>(
+				draft.customerGroup,
+				context.projectKey,
+				storage,
+			)
+		: undefined,
+	recurrencePolicy: draft.recurrencePolicy
+		? await getReferenceFromResourceIdentifier<RecurrencePolicyReference>(
+				draft.recurrencePolicy,
+				context.projectKey,
+				storage,
+			)
+		: undefined,
+	validFrom: draft.validFrom,
+	validUntil: draft.validUntil,
+	discounted: draft.discounted
+		? {
+				value: createTypedMoney(draft.discounted.value),
+				discount: draft.discounted.discount,
+			}
+		: undefined,
+	tiers: draft.tiers?.map((tier) => ({
+		minimumQuantity: tier.minimumQuantity,
+		value: createTypedMoney(tier.value),
+	})),
+	custom: await createCustomFields(draft.custom, context.projectKey, storage),
 });


### PR DESCRIPTION
Fixes #283.

`priceFromDraft` mapped `key`, `country`, `value` and `channel`. Everything else in `PriceDraft` was dropped: `customerGroup`, `validFrom`, `validUntil`, `discounted`, `tiers`, `custom`, `recurrencePolicy`.

`customerGroup` is the one the issue names, and it is the most damaging: a price created for a customer group reads back without one, so customer-group price selection cannot be exercised against the mock at all.

## Also removed: the second price mapping

The order import did not use `priceFromDraft` — it used `createPrice` in `repositories/helpers.ts`, which kept only `id` and `value` and dropped even the country. Fixing the same gap in two places seemed worse than having one mapping, so both call sites in `OrderRepository.lineItemFromImportDraft` now use `priceFromDraft` and `createPrice` is deleted. It was internal — not exported from `src/index.ts`.

## Coverage

New `src/repositories/product/helpers.test.ts`: one test asserting a fully populated draft round-trips (with `customerGroup` and `channel` resolved from resource identifiers to references), one asserting unset fields stay unset.

Full suite: 792 passing.