### PR TITLE
feat: implement the product-projection suggest endpoint

### DIFF
--- a/.changeset/product-projection-suggest.md
+++ b/.changeset/product-projection-suggest.md
@@ -1,0 +1,16 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Implement the product-projection suggest endpoint,
+`GET /{projectKey}/product-projections/suggest`.
+
+Suggestions come from the products' `searchKeywords` for each requested locale.
+Matching is a case-insensitive prefix match on the keyword's tokens, so a
+keyword only matches mid-word when it carries a `whitespace` or `custom`
+`suggestTokenizer` — the same rule as commercetools. `fuzzy` allows edits up to
+`fuzzyLevel`, defaulting to the level commercetools derives from the length of
+the search term, and `staged` and `limit` are honoured. A request without a
+`searchKeywords.{language}` parameter is rejected with `InvalidInput`.
+
+No search dependency was added; the matching is a few lines in the repository.

--- a/src/repositories/product-projection.ts
+++ b/src/repositories/product-projection.ts
@@ -4,6 +4,8 @@ import type {
 	ProductDraft,
 	ProductProjection,
 	QueryParam,
+	SearchKeyword,
+	SuggestionResult,
 } from "@commercetools/platform-sdk";
 import type { Config } from "#src/config.ts";
 import { CommercetoolsError } from "#src/exceptions.ts";
@@ -29,6 +31,76 @@ export type ProductProjectionQueryParams = {
 	withTotal?: boolean;
 	where?: string | string[];
 	[key: string]: QueryParam;
+};
+
+export type ProductProjectionSuggestParams = {
+	searchKeywords: Record<string, string>;
+	staged?: boolean;
+	fuzzy?: boolean;
+	fuzzyLevel?: number;
+	limit?: number;
+};
+
+const DEFAULT_SUGGEST_LIMIT = 10;
+
+/**
+ * commercetools suggests on the tokens of a search keyword, so "tool" only
+ * matches "Multi tool" when the keyword is tokenized.
+ */
+const keywordTokens = (keyword: SearchKeyword): string[] => {
+	const tokenizer = keyword.suggestTokenizer;
+	if (!tokenizer) {
+		return [keyword.text];
+	}
+	if (tokenizer.type === "custom") {
+		return tokenizer.inputs;
+	}
+	return keyword.text.split(/\s+/).filter(Boolean);
+};
+
+/**
+ * The fuzzy level commercetools derives from the length of the search term when
+ * `fuzzyLevel` is not given.
+ *
+ * @see https://docs.commercetools.com/api/projects/products-search#fuzzy-search
+ */
+const defaultFuzzyLevel = (term: string) => {
+	if (term.length < 3) return 0;
+	if (term.length < 6) return 1;
+	return 2;
+};
+
+/**
+ * Damerau-Levenshtein (optimal string alignment) distance: the same metric
+ * Elasticsearch uses for fuzziness, so a transposed pair of characters counts
+ * as one edit rather than two.
+ */
+const editDistance = (a: string, b: string): number => {
+	const rows: number[][] = [Array.from({ length: b.length + 1 }, (_, i) => i)];
+
+	for (let i = 1; i <= a.length; i++) {
+		const current = [i];
+		for (let j = 1; j <= b.length; j++) {
+			const previous = rows[i - 1];
+			current[j] = Math.min(
+				previous[j] + 1,
+				current[j - 1] + 1,
+				previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+			);
+			if (
+				i > 1 &&
+				j > 1 &&
+				a[i - 1] === b[j - 2] &&
+				a[i - 2] === b[j - 1] &&
+				rows[i - 2] !== undefined
+			) {
+				current[j] = Math.min(current[j], rows[i - 2][j - 2] + 1);
+			}
+		}
+		rows[i] = current;
+	}
+
+	return rows[a.length][b.length];
 };
 
 export class ProductProjectionRepository extends AbstractResourceRepository<"product-projection"> {
@@ -167,5 +239,51 @@ export class ProductProjectionRepository extends AbstractResourceRepository<"pro
 
 	search(context: RepositoryContext, query: ProductProjectionQueryParams) {
 		return this._searchService.search(context.projectKey, query);
+	}
+
+	async suggest(
+		context: RepositoryContext,
+		params: ProductProjectionSuggestParams,
+	): Promise<SuggestionResult> {
+		const staged = params.staged ?? false;
+		const allProducts = await this._storage.all(context.projectKey, "product");
+		const projections = (
+			await Promise.all(
+				allProducts.map((product) =>
+					this._searchService.transform(product, staged, context.projectKey),
+				),
+			)
+		).filter((projection) => staged || projection.published);
+
+		const limit = params.limit ?? DEFAULT_SUGGEST_LIMIT;
+		const result: SuggestionResult = {};
+
+		for (const [locale, term] of Object.entries(params.searchKeywords)) {
+			const needle = term.toLowerCase();
+			const level = params.fuzzy
+				? (params.fuzzyLevel ?? defaultFuzzyLevel(term))
+				: 0;
+
+			const texts = new Set<string>();
+			for (const projection of projections) {
+				for (const keyword of projection.searchKeywords?.[locale] ?? []) {
+					const matches = keywordTokens(keyword).some((token) => {
+						const prefix = token.slice(0, needle.length).toLowerCase();
+						return level === 0
+							? prefix === needle
+							: editDistance(prefix, needle) <= level;
+					});
+					if (matches) {
+						texts.add(keyword.text);
+					}
+				}
+			}
+
+			result[`searchKeywords.${locale}`] = [...texts]
+				.slice(0, limit)
+				.map((text) => ({ text }));
+		}
+
+		return result;
 	}
 }

--- a/src/services/product-projection.test.ts
+++ b/src/services/product-projection.test.ts
@@ -637,6 +637,119 @@ describe("Product Projection Search - Facets", () => {
 	});
 });
 
+describe("Product Projection Suggest", () => {
+	const suggest = (query: Record<string, string>) =>
+		ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/product-projections/suggest",
+			query,
+		});
+
+	beforeEach(async () => {
+		await productFactory.create({
+			publish: true,
+			key: "multi-tool",
+			name: { en: "Multi tool" },
+			slug: { en: "multi-tool" },
+			productType: { typeId: "product-type", id: productType.id },
+			searchKeywords: {
+				en: [
+					{ text: "Multi tool" },
+					{
+						text: "Swiss army knife",
+						suggestTokenizer: { type: "whitespace" },
+					},
+				],
+				"nl-NL": [{ text: "Zakmes" }],
+			},
+		});
+
+		await productFactory.create({
+			publish: false,
+			key: "unpublished-tool",
+			name: { en: "Draft tool" },
+			slug: { en: "draft-tool" },
+			productType: { typeId: "product-type", id: productType.id },
+			searchKeywords: {
+				en: [{ text: "Staged only keyword" }],
+			},
+		});
+	});
+
+	test("suggests on a keyword prefix", async () => {
+		const response = await suggest({ "searchKeywords.en": "multi" });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			"searchKeywords.en": [{ text: "Multi tool" }],
+		});
+	});
+
+	test("only matches a prefix of the keyword", async () => {
+		const response = await suggest({ "searchKeywords.en": "tool" });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()["searchKeywords.en"]).toEqual([]);
+	});
+
+	test("a whitespace tokenizer makes every word a prefix", async () => {
+		const response = await suggest({ "searchKeywords.en": "army" });
+
+		expect(response.json()["searchKeywords.en"]).toEqual([
+			{ text: "Swiss army knife" },
+		]);
+	});
+
+	test("suggests per requested locale", async () => {
+		const response = await suggest({
+			"searchKeywords.en": "multi",
+			"searchKeywords.nl-NL": "zak",
+		});
+
+		expect(response.json()).toEqual({
+			"searchKeywords.en": [{ text: "Multi tool" }],
+			"searchKeywords.nl-NL": [{ text: "Zakmes" }],
+		});
+	});
+
+	test("a typo only matches with fuzzy", async () => {
+		const exact = await suggest({ "searchKeywords.en": "mutli" });
+		expect(exact.json()["searchKeywords.en"]).toEqual([]);
+
+		const fuzzy = await suggest({
+			"searchKeywords.en": "mutli",
+			fuzzy: "true",
+		});
+		expect(fuzzy.json()["searchKeywords.en"]).toEqual([{ text: "Multi tool" }]);
+	});
+
+	test("unpublished keywords need staged", async () => {
+		const current = await suggest({ "searchKeywords.en": "staged" });
+		expect(current.json()["searchKeywords.en"]).toEqual([]);
+
+		const staged = await suggest({
+			"searchKeywords.en": "staged",
+			staged: "true",
+		});
+		expect(staged.json()["searchKeywords.en"]).toEqual([
+			{ text: "Staged only keyword" },
+		]);
+	});
+
+	test("limit caps the suggestions", async () => {
+		const response = await suggest({ "searchKeywords.en": "s", limit: "0" });
+
+		expect(response.json()["searchKeywords.en"]).toEqual([]);
+	});
+
+	test("without a searchKeywords parameter", async () => {
+		const response = await suggest({});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().errors[0].code).toBe("InvalidInput");
+	});
+});
+
 describe("Product Projection Query - sorting", () => {
 	const many = 6;
 

--- a/src/services/product-projection.ts
+++ b/src/services/product-projection.ts
@@ -1,4 +1,6 @@
+import type { InvalidInputError } from "@commercetools/platform-sdk";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { CommercetoolsError } from "#src/exceptions.ts";
 import { queryParamsArray, queryParamsValue } from "../helpers.ts";
 import { getRepositoryContext } from "../repositories/helpers.ts";
 import type {
@@ -24,6 +26,7 @@ export class ProductProjectionService extends AbstractService {
 
 	extraRoutes(instance: FastifyInstance) {
 		instance.get("/search", this.search.bind(this));
+		instance.get("/suggest", this.suggest.bind(this));
 	}
 
 	async get(
@@ -45,6 +48,50 @@ export class ProductProjectionService extends AbstractService {
 			offset: offset !== undefined ? Number(offset) : undefined,
 		});
 		return reply.status(200).send(result);
+	}
+
+	async suggest(
+		request: FastifyRequest<{
+			Params: Record<string, string>;
+			Querystring: Record<string, any>;
+		}>,
+		reply: FastifyReply,
+	) {
+		const query = request.query;
+		const searchKeywords: Record<string, string> = {};
+		for (const key in query) {
+			if (key.startsWith("searchKeywords.")) {
+				const value = queryParamsValue(query[key]);
+				if (value !== undefined) {
+					searchKeywords[key.substring("searchKeywords.".length)] = value;
+				}
+			}
+		}
+
+		if (Object.keys(searchKeywords).length === 0) {
+			throw new CommercetoolsError<InvalidInputError>(
+				{
+					code: "InvalidInput",
+					message:
+						"Required parameter 'searchKeywords.{language}' is missing or invalid.",
+				},
+				400,
+			);
+		}
+
+		const limit = queryParamsValue(query.limit);
+		const fuzzyLevel = queryParamsValue(query.fuzzyLevel);
+		const resource = await this.repository.suggest(
+			getRepositoryContext(request),
+			{
+				searchKeywords,
+				staged: queryParamsValue(query.staged) === "true",
+				fuzzy: queryParamsValue(query.fuzzy) === "true",
+				fuzzyLevel: fuzzyLevel !== undefined ? Number(fuzzyLevel) : undefined,
+				limit: limit !== undefined ? Number(limit) : undefined,
+			},
+		);
+		return reply.status(200).send(resource);
 	}
 
 	async search(


### PR DESCRIPTION
Fixes #165.

`GET /{projectKey}/product-projections/suggest` now works, built on the products' `searchKeywords`.

## Matching rules

Followed the documented behaviour rather than a convenient substring match, because a suggest endpoint that matches too eagerly gives tests a pass they have not earned:

- Case-insensitive **prefix** match, per requested locale.
- Matching happens on the keyword's **tokens**: no `suggestTokenizer` means the whole text is one token, so `searchKeywords.en=tool` does *not* suggest `"Multi tool"`, while `multi` does. `{ type: "whitespace" }` makes each word a token, `{ type: "custom" }` uses its `inputs`.
- `fuzzy=true` allows edits up to `fuzzyLevel`; without one, the level commercetools derives from the term length (0 / 1 / 2 for <3, <6, longer).
- `staged` and `limit` are honoured; unpublished products only contribute with `staged=true`.
- No `searchKeywords.{language}` parameter → `InvalidInput` (400).

The distance is Damerau-Levenshtein (optimal string alignment), the metric Elasticsearch uses for fuzziness, so a transposition is one edit and `mutli` suggests `"Multi tool"`. Plain Levenshtein would score that 2 and miss it at the default level.

## No new dependency

The issue suggested Fuse.js. The matching turned out to be a few lines in `ProductProjectionRepository`, so no dependency was added — worth avoiding in a test double.

## Coverage

Eight tests in `product-projection.test.ts`: prefix match, non-prefix miss, whitespace tokenizer, multi-locale request, typo with and without `fuzzy`, unpublished keywords with and without `staged`, `limit`, and the missing-parameter error.

Full suite: 798 passing.