### PR TITLE
feat: validate subscription destinations and add the missing update actions

### DIFF
--- a/.changeset/subscription-destination-validation.md
+++ b/.changeset/subscription-destination-validation.md
@@ -1,0 +1,15 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Validate subscription destinations per type, and support the remaining
+subscription update actions.
+
+The generated `DestinationSchema` only carries the `type` discriminator, because
+the spec models `Destination` as a union — so in strict mode a subscription
+draft could be missing everything its destination needs (an SQS destination
+without a `region`, say) and still be accepted. The destination is now validated
+as a discriminated union over the seven destination types.
+
+`changeDestination`, `setChanges`, `setEvents` and `setMessages` are implemented;
+`setKey` was the only update action the handler had.

--- a/src/repositories/subscription.ts
+++ b/src/repositories/subscription.ts
@@ -1,13 +1,17 @@
 import type {
 	InvalidInputError,
 	Subscription,
+	SubscriptionChangeDestinationAction,
 	SubscriptionDraft,
+	SubscriptionSetChangesAction,
+	SubscriptionSetEventsAction,
 	SubscriptionSetKeyAction,
+	SubscriptionSetMessagesAction,
 	SubscriptionUpdateAction,
 } from "@commercetools/platform-sdk";
 import type { Config } from "#src/config.ts";
 import { CommercetoolsError } from "#src/exceptions.ts";
-import { SubscriptionDraftSchema } from "#src/schemas/generated/subscription.ts";
+import { SubscriptionDraftWithDestinationSchema } from "#src/schemas/subscription.ts";
 import { getBaseResourceProperties } from "../helpers.ts";
 import type { Writable } from "../types.ts";
 import type { RepositoryContext, UpdateHandlerInterface } from "./abstract.ts";
@@ -20,7 +24,7 @@ export class SubscriptionRepository extends AbstractResourceRepository<"subscrip
 	constructor(config: Config) {
 		super("subscription", config);
 		this.actions = new SubscriptionUpdateHandler(config.storage);
-		this.draftSchema = SubscriptionDraftSchema;
+		this.draftSchema = SubscriptionDraftWithDestinationSchema;
 	}
 
 	async create(
@@ -65,11 +69,43 @@ class SubscriptionUpdateHandler
 	implements
 		Partial<UpdateHandlerInterface<Subscription, SubscriptionUpdateAction>>
 {
+	changeDestination(
+		_context: RepositoryContext,
+		resource: Writable<Subscription>,
+		{ destination }: SubscriptionChangeDestinationAction,
+	) {
+		resource.destination = destination;
+	}
+
+	setChanges(
+		_context: RepositoryContext,
+		resource: Writable<Subscription>,
+		{ changes }: SubscriptionSetChangesAction,
+	) {
+		resource.changes = changes ?? [];
+	}
+
+	setEvents(
+		_context: RepositoryContext,
+		resource: Writable<Subscription>,
+		{ events }: SubscriptionSetEventsAction,
+	) {
+		resource.events = events ?? [];
+	}
+
 	setKey(
 		_context: RepositoryContext,
 		resource: Writable<Subscription>,
 		{ key }: SubscriptionSetKeyAction,
 	) {
 		resource.key = key;
+	}
+
+	setMessages(
+		_context: RepositoryContext,
+		resource: Writable<Subscription>,
+		{ messages }: SubscriptionSetMessagesAction,
+	) {
+		resource.messages = messages ?? [];
 	}
 }

--- a/src/schemas/subscription.ts
+++ b/src/schemas/subscription.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { DeliveryFormatSchema } from "./generated/common.ts";
+import { SubscriptionDraftSchema } from "./generated/subscription.ts";
+
+/**
+ * The generated `DestinationSchema` only carries the discriminator, because the
+ * OpenAPI spec models Destination as a union. Validating the variants is the
+ * point of this endpoint for consumers that generate subscriptions (for example
+ * the Terraform provider), so the variants are spelled out here.
+ *
+ * @see https://docs.commercetools.com/api/projects/subscriptions#destination
+ */
+const SubscriptionDestinationSchema = z.discriminatedUnion("type", [
+	z.object({
+		type: z.literal("SQS"),
+		queueUrl: z.string(),
+		region: z.string(),
+		accessKey: z.string().nullish(),
+		accessSecret: z.string().nullish(),
+		authenticationMode: z.enum(["Credentials", "IAM"]).nullish(),
+	}),
+	z.object({
+		type: z.literal("SNS"),
+		topicArn: z.string(),
+		accessKey: z.string().nullish(),
+		accessSecret: z.string().nullish(),
+		authenticationMode: z.enum(["Credentials", "IAM"]).nullish(),
+	}),
+	z.object({
+		type: z.literal("EventBridge"),
+		region: z.string(),
+		accountId: z.string(),
+	}),
+	z.object({
+		type: z.literal("GoogleCloudPubSub"),
+		projectId: z.string(),
+		topic: z.string(),
+	}),
+	z.object({
+		type: z.literal("EventGrid"),
+		uri: z.string(),
+		accessKey: z.string(),
+	}),
+	z.object({
+		type: z.literal("AzureServiceBus"),
+		connectionString: z.string(),
+	}),
+	z.object({
+		type: z.literal("ConfluentCloud"),
+		bootstrapServer: z.string(),
+		apiKey: z.string(),
+		apiSecret: z.string(),
+		acks: z.string(),
+		topic: z.string(),
+		key: z.string().nullish(),
+	}),
+]);
+
+export const SubscriptionDraftWithDestinationSchema =
+	SubscriptionDraftSchema.extend({
+		destination: SubscriptionDestinationSchema,
+		format: DeliveryFormatSchema.nullish(),
+	});

--- a/src/services/subscription.test.ts
+++ b/src/services/subscription.test.ts
@@ -143,4 +143,95 @@ describe("Subscription", () => {
 		expect(response.json().count).toBeGreaterThan(0);
 		expect(response.json().results).toContainEqual(subscription);
 	});
+	test("Update subscription", async () => {
+		const created = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/subscriptions",
+			payload: {
+				key: "updatable",
+				destination: {
+					type: "GoogleCloudPubSub",
+					projectId: "my-project",
+					topic: "my-topic",
+				},
+				messages: [{ resourceTypeId: "order", types: ["OrderCreated"] }],
+			},
+		});
+		expect(created.statusCode).toBe(201);
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/subscriptions/${created.json().id}`,
+			payload: {
+				version: created.json().version,
+				actions: [
+					{
+						action: "changeDestination",
+						destination: {
+							type: "GoogleCloudPubSub",
+							projectId: "other-project",
+							topic: "other-topic",
+						},
+					},
+					{ action: "setMessages", messages: [] },
+					{ action: "setChanges", changes: [{ resourceTypeId: "product" }] },
+					{
+						action: "setEvents",
+						events: [
+							{
+								resourceTypeId: "import-api",
+								types: ["ImportContainerCreated"],
+							},
+						],
+					},
+					{ action: "setKey", key: "updated" },
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().destination.topic).toBe("other-topic");
+		expect(response.json().messages).toEqual([]);
+		expect(response.json().changes).toEqual([{ resourceTypeId: "product" }]);
+		expect(response.json().events).toEqual([
+			{ resourceTypeId: "import-api", types: ["ImportContainerCreated"] },
+		]);
+		expect(response.json().key).toBe("updated");
+	});
+});
+
+describe("Subscription draft validation", () => {
+	const ctMock = new CommercetoolsMock({ strict: true });
+
+	test("Create subscription with an incomplete destination", async () => {
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/subscriptions",
+			payload: {
+				key: "incomplete",
+				destination: {
+					type: "SQS",
+					queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789/orders",
+				},
+				messages: [{ resourceTypeId: "order", types: ["OrderCreated"] }],
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().errors[0].code).toBe("InvalidJsonInput");
+		expect(response.json().errors[0].detailedErrorMessage).toContain("region");
+	});
+
+	test("Create subscription with an unknown destination type", async () => {
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/subscriptions",
+			payload: {
+				key: "unknown-destination",
+				destination: { type: "Carrier pigeon" },
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
 });


### PR DESCRIPTION
Addresses the concrete half of #76.

## Destination validation

`src/schemas/generated/common.ts` has `DestinationSchema = z.object({ type: z.string() })` — the generator flattens the `Destination` union to its base type. So in strict mode a draft like

```json
{ "destination": { "type": "SQS", "queueUrl": "https://…/orders" } }
```

was accepted, missing `region` entirely. That is the gap the issue describes: the Terraform provider sees no error when properties are missing.

The destination is now validated as a `z.discriminatedUnion("type", …)` over the seven types the SDK models: SQS, SNS, EventBridge, GoogleCloudPubSub, EventGrid, AzureServiceBus, ConfluentCloud. It lives in a hand-written `src/schemas/subscription.ts` (the generated directory says not to edit it) and extends `SubscriptionDraftSchema`, so everything else in the draft still uses the generated schema.

Note this only bites with `strict: true` — `AbstractService.post` only validates drafts in strict mode. Worth knowing for the Terraform provider's use of the mock.

## Update actions

`SubscriptionUpdateHandler` only had `setKey`. Added `changeDestination`, `setChanges`, `setEvents` and `setMessages`, which is the full `SubscriptionUpdateAction` union.

## What is left of #76

The issue asks for a "proper mock implementation" in general; delivering an actual test message to a destination (the `TestDestination` behaviour, currently faked by the hardcoded `0000000000` account id) is not part of this PR, so I have marked the commit `Refs #76` rather than `Fixes`.

## Coverage

`subscription.test.ts`: an incomplete SQS destination and an unknown destination type both rejected in strict mode, plus one test applying all five update actions in a single request.

Full suite: 793 passing.