### PR TITLE
feat!: scope the /me and as-associate endpoints to the caller

### DIFF
--- a/.changeset/associate-permissions.md
+++ b/.changeset/associate-permissions.md
@@ -1,0 +1,45 @@
+---
+"@labdigital/commercetools-mock": major
+---
+
+Scope the `/me` and `as-associate` endpoints to the caller, and fail closed.
+
+**This is a breaking change.** Both scopes used to answer from the whole
+collection: `/me/orders/{id}` returned any order, and an associate-scoped
+request accepted any `associateId` and ignored the business unit in the path.
+A test asserting that a shopper cannot read someone else's order, or that an
+associate cannot see a colleague's cart, passed whether or not the code under
+test actually scoped its request.
+
+**`/me`** now answers for the customer or anonymous session the bearer token was
+issued for, and returns `403 insufficient_scope` without one. A resource
+belonging to someone else is `404`, not a leak. Resources created through `/me`
+are stamped with the caller.
+
+**`as-associate`** resolves the associate named in the path against the business
+unit named in the path, collects the permissions of their AssociateRoles, and
+enforces all 47 of them. `My` means the resource's customer is the acting
+associate; `Others` means a different customer in the same business unit. A list
+request with only the `My` permission is narrowed rather than refused; anything
+else missing returns `403 AssociateMissingPermission` carrying the permissions
+that would have sufficed. A resource of another business unit is `404`.
+
+**Migrating.** Tests that call these endpoints now need to say who is calling.
+A new `@labdigital/commercetools-mock/testing` entrypoint exports
+`customerSession`, `loginCustomer` and `anonymousSession` for `/me`, and
+`createAssociateScope` for the associate scope, which seeds the customer,
+associate role and business unit in one call.
+
+Identity resolution no longer depends on `enableAuthentication`: the mock always
+reads the identity from a token it issued, so scoping works without turning
+authentication on.
+
+Also in this change, because the scopes are unusable without them:
+
+- `POST /oauth/{projectKey}/anonymous/token` honours a supplied `anonymous_id`
+  instead of always generating one.
+- `PaymentDraft.customer` and `anonymousId` are stored.
+- An order and a quote request created from a cart carry the cart's
+  `businessUnit`.
+- `GET /me/active-cart` answers for the caller instead of returning the first
+  active cart in the project.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,4 @@
+{
+  "mode": "pre",
+  "tag": "beta"
+}

--- a/docs/src/content/docs/configuration/authentication.md
+++ b/docs/src/content/docs/configuration/authentication.md
@@ -91,13 +91,67 @@ await apiRoot
 ```
 
 A matching customer yields a token whose scope carries `customer_id:<id>`; no
-match returns `400 invalid_customer_account_credentials`.
+match returns `400 invalid_customer_account_credentials`. That `customer_id` is
+what the `/me` endpoints answer for — see [Scoped endpoints](#scoped-endpoints).
 
 ## Anonymous grant
 
 `POST /oauth/{projectKey}/anonymous/token` issues a token with an
 `anonymous_id:<uuid>` appended to the scope — useful for testing anonymous cart
-flows.
+flows. Pass `anonymous_id` yourself to continue an existing session.
+
+## Scoped endpoints
+
+The `/me` and `as-associate` endpoints answer for a particular caller, and both
+**fail closed**: a request that does not establish who is asking is refused
+rather than served from the whole collection. Returning another customer's order
+to an unidentified caller would make an ownership test pass without asserting
+anything.
+
+### `/me`
+
+The caller is the customer (or anonymous session) the bearer token was issued
+for. Without such a token, `/me` returns `403 insufficient_scope`.
+
+```typescript
+import { customerSession } from '@labdigital/commercetools-mock/testing'
+
+const { headers } = customerSession(ctMock, customer.id)
+
+await ctMock.app.inject({ method: 'GET', url: '/my-project/me/orders', headers })
+```
+
+`loginCustomer` does the same through the password grant when you want to
+exercise sign-in, and `anonymousSession` starts an anonymous one. Resources
+created through `/me` are stamped with the caller, so they can be read back.
+
+### `as-associate`
+
+The caller is the associate named in the path,
+`/as-associate/{associateId}/in-business-unit/key={key}/…`. The mock resolves
+the business unit, finds that associate on it, and collects the permissions of
+their AssociateRoles. What each request needs follows commercetools:
+
+- The `My` permission (`ViewMyOrders`) covers resources whose customer is the
+  associate; the `Others` permission (`ViewOthersOrders`) covers the rest of the
+  business unit.
+- A list request with only the `My` permission is narrowed to the caller instead
+  of being refused.
+- Missing permissions return `403 AssociateMissingPermission`, carrying the
+  permissions that would have sufficed.
+- A resource of another business unit is `404`, not `403`.
+
+`createAssociateScope` seeds the customer, role and business unit for you:
+
+```typescript
+import { createAssociateScope } from '@labdigital/commercetools-mock/testing'
+
+const scope = await createAssociateScope(ctMock, {
+  permissions: ['ViewMyCarts', 'CreateMyCarts'],
+})
+
+await ctMock.app.inject({ method: 'GET', url: `${scope.basePath}/carts` })
+```
 
 ## Gotchas & limitations
 
@@ -112,9 +166,9 @@ These differ from real commercetools and are worth knowing when writing tests:
   cannot be simulated; `validateCredentials` only checks that a token exists.
 - **Scope defaults to the literal `"todo"`** for client tokens when none is
   requested.
-- **`/me` endpoints do not consume the token's `customer_id` scope.** Customer
-  identity for `/me` routes comes from the request payload (e.g. login), not from
-  the bearer token. Per-customer data isolation on `/me` is therefore not
-  enforced based on the token.
+- **Identity resolution is independent of `enableAuthentication`.** The mock
+  always reads the identity out of a bearer token it issued, so `/me` and
+  `as-associate` can be scoped without turning on authentication. Turning
+  `validateCredentials` on additionally *requires* a token on every API call.
 
 See also: [API coverage & limitations](/commercetools-node-mock/reference/resources/).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 	"sideEffects": false,
 	"exports": {
 		".": "./dist/index.mjs",
-		"./sqlite": "./dist/storage/sqlite.mjs"
+		"./sqlite": "./dist/storage/sqlite.mjs",
+		"./testing": "./dist/testing/index.mjs"
 	},
 	"imports": {
 		"#src/*": "./src/*",

--- a/src/associate-permissions.ts
+++ b/src/associate-permissions.ts
@@ -1,0 +1,290 @@
+/**
+ * Permission checking for the associate-scoped (`as-associate`) endpoints.
+ *
+ * commercetools decides what an associate may see and do from the permissions
+ * on the AssociateRoles assigned to them in the business unit named in the
+ * path. Every permission is split into a `My` and an `Others` variant:
+ *
+ * - `My` means the resource belongs to the acting associate: its customer is
+ *   the associate in the path.
+ * - `Others` means the resource belongs to a different customer within the
+ *   same business unit.
+ *
+ * The checks fail closed. An associate that cannot be resolved, or that lacks
+ * the permission for what the request is asking, is refused — rather than
+ * silently granted, which would turn an authorisation test into one that
+ * passes without asserting anything.
+ *
+ * @see https://docs.commercetools.com/api/projects/associate-roles#permission
+ */
+import type {
+	AssociateMissingPermissionError,
+	BusinessUnit,
+	Permission,
+	ResourceNotFoundError,
+	UpdateAction,
+} from "@commercetools/platform-sdk";
+import { CommercetoolsError } from "#src/exceptions.ts";
+import type { RepositoryContext } from "#src/repositories/abstract.ts";
+import type { AbstractStorage } from "#src/storage/index.ts";
+
+export type AssociateScope = "my" | "others";
+
+/** A permission pair: the `My` variant first, the `Others` variant second. */
+export type PermissionPair = readonly [Permission, Permission];
+
+export const permissionFor = (
+	pair: PermissionPair,
+	scope: AssociateScope,
+): Permission => (scope === "my" ? pair[0] : pair[1]);
+
+// ---------------------------------------------------------------------------
+// The permission table
+// ---------------------------------------------------------------------------
+
+export const CART_PERMISSIONS = {
+	view: ["ViewMyCarts", "ViewOthersCarts"],
+	create: ["CreateMyCarts", "CreateOthersCarts"],
+	update: ["UpdateMyCarts", "UpdateOthersCarts"],
+	delete: ["DeleteMyCarts", "DeleteOthersCarts"],
+} as const;
+
+export const ORDER_PERMISSIONS = {
+	view: ["ViewMyOrders", "ViewOthersOrders"],
+	create: ["CreateMyOrdersFromMyCarts", "CreateOrdersFromOthersCarts"],
+	update: ["UpdateMyOrders", "UpdateOthersOrders"],
+} as const;
+
+/** Creating an order from a quote is a different permission than from a cart. */
+export const ORDER_FROM_QUOTE_PERMISSIONS = [
+	"CreateMyOrdersFromMyQuotes",
+	"CreateOrdersFromOthersQuotes",
+] as const;
+
+export const QUOTE_PERMISSIONS = {
+	view: ["ViewMyQuotes", "ViewOthersQuotes"],
+} as const;
+
+/**
+ * Quotes have no blanket update permission: what an associate may do depends on
+ * the action. An action that is not listed here needs the view permission only,
+ * since it does not move the quote through the negotiation.
+ */
+export const QUOTE_ACTION_PERMISSIONS: Record<string, PermissionPair> = {
+	"changeQuoteState:Accepted": ["AcceptMyQuotes", "AcceptOthersQuotes"],
+	"changeQuoteState:Declined": ["DeclineMyQuotes", "DeclineOthersQuotes"],
+	requestQuoteRenegotiation: ["RenegotiateMyQuotes", "RenegotiateOthersQuotes"],
+	changeCustomer: ["ReassignMyQuotes", "ReassignOthersQuotes"],
+};
+
+export const QUOTE_REQUEST_PERMISSIONS = {
+	view: ["ViewMyQuoteRequests", "ViewOthersQuoteRequests"],
+	create: [
+		"CreateMyQuoteRequestsFromMyCarts",
+		"CreateQuoteRequestsFromOthersCarts",
+	],
+	update: ["UpdateMyQuoteRequests", "UpdateOthersQuoteRequests"],
+} as const;
+
+export const SHOPPING_LIST_PERMISSIONS = {
+	view: ["ViewMyShoppingLists", "ViewOthersShoppingLists"],
+	create: ["CreateMyShoppingLists", "CreateOthersShoppingLists"],
+	update: ["UpdateMyShoppingLists", "UpdateOthersShoppingLists"],
+	delete: ["DeleteMyShoppingLists", "DeleteOthersShoppingLists"],
+} as const;
+
+/**
+ * Business units, approval rules and approval flows have no `My`/`Others`
+ * split: the resource is the business unit the associate is acting in, so the
+ * permission is the same either way.
+ */
+export const BUSINESS_UNIT_ACTION_PERMISSIONS: Record<string, Permission> = {
+	addAssociate: "UpdateAssociates",
+	changeAssociate: "UpdateAssociates",
+	removeAssociate: "UpdateAssociates",
+	setAssociates: "UpdateAssociates",
+	changeParentUnit: "UpdateParentUnit",
+	setParentUnit: "UpdateParentUnit",
+};
+
+/** Anything else on a business unit changes its details. */
+export const BUSINESS_UNIT_DETAILS_PERMISSION: Permission =
+	"UpdateBusinessUnitDetails";
+
+export const BUSINESS_UNIT_CREATE_PERMISSION: Permission = "AddChildUnits";
+
+export const APPROVAL_RULE_CREATE_PERMISSION: Permission =
+	"CreateApprovalRules";
+export const APPROVAL_RULE_UPDATE_PERMISSION: Permission =
+	"UpdateApprovalRules";
+export const APPROVAL_FLOW_UPDATE_PERMISSION: Permission =
+	"UpdateApprovalFlows";
+
+// ---------------------------------------------------------------------------
+// Resolving the acting associate
+// ---------------------------------------------------------------------------
+
+/**
+ * The message shape commercetools uses for this error.
+ *
+ * @see https://docs.commercetools.com/api/errors#associatemissingpermission
+ */
+const missingPermission = (
+	context: RepositoryContext,
+	action: string,
+	permissions: Permission[],
+	forCustomerId?: string,
+): CommercetoolsError<AssociateMissingPermissionError> => {
+	const needs = permissions.map((p) => `'${p}'`).join(" or ");
+	const onBehalf =
+		forCustomerId && forCustomerId !== context.associateId
+			? ` for customer '${forCustomerId}'`
+			: "";
+
+	return new CommercetoolsError<AssociateMissingPermissionError>(
+		{
+			code: "AssociateMissingPermission",
+			message: `Associate '${context.associateId}' has no rights to ${action}${onBehalf} in business-unit '${context.businessUnitKey}'.${needs ? ` Needs ${needs}.` : ""}`,
+			associate: { typeId: "customer", id: context.associateId },
+			businessUnit: { typeId: "business-unit", key: context.businessUnitKey },
+			permissions,
+		},
+		403,
+	);
+};
+
+const roleKeysFor = (
+	businessUnit: BusinessUnit,
+	associateId: string,
+): string[] | undefined => {
+	const associate = businessUnit.associates?.find(
+		(candidate) => candidate.customer.id === associateId,
+	);
+	if (associate) {
+		return associate.associateRoleAssignments.map(
+			(assignment) => assignment.associateRole.key,
+		);
+	}
+
+	// An associate of a parent unit is an associate of its divisions
+	const inherited = businessUnit.inheritedAssociates?.find(
+		(candidate) => candidate.customer.id === associateId,
+	);
+	return inherited?.associateRoleAssignments.map(
+		(assignment) => assignment.associateRole.key,
+	);
+};
+
+export type AssociateContext = {
+	associateId: string;
+	businessUnit: BusinessUnit;
+	permissions: Set<Permission>;
+};
+
+/**
+ * Resolves the associate named in the path together with the permissions they
+ * hold in the business unit named in the path.
+ */
+export const resolveAssociateContext = async (
+	context: RepositoryContext,
+	storage: AbstractStorage,
+	/** The unit to resolve against, when it is not the one in the path. */
+	businessUnitKeyOverride?: string,
+): Promise<AssociateContext> => {
+	const { associateId, projectKey } = context;
+	const businessUnitKey = businessUnitKeyOverride ?? context.businessUnitKey;
+
+	if (!associateId || !businessUnitKey) {
+		throw missingPermission(context, "act", []);
+	}
+
+	const businessUnit = await storage.getByKey<"business-unit">(
+		projectKey,
+		"business-unit",
+		businessUnitKey,
+	);
+	if (!businessUnit) {
+		throw new CommercetoolsError<ResourceNotFoundError>(
+			{
+				code: "ResourceNotFound",
+				message: `The business unit with key '${businessUnitKey}' was not found.`,
+			},
+			404,
+		);
+	}
+
+	const roleKeys = roleKeysFor(businessUnit, associateId);
+	if (!roleKeys) {
+		throw missingPermission(context, "act", []);
+	}
+
+	const permissions = new Set<Permission>();
+	for (const key of roleKeys) {
+		const role = await storage.getByKey<"associate-role">(
+			projectKey,
+			"associate-role",
+			key,
+		);
+		for (const permission of role?.permissions ?? []) {
+			permissions.add(permission);
+		}
+	}
+
+	return { associateId, businessUnit, permissions };
+};
+
+export const hasPermission = (
+	associate: AssociateContext,
+	permission: Permission,
+): boolean => associate.permissions.has(permission);
+
+export const requirePermission = (
+	context: RepositoryContext,
+	associate: AssociateContext,
+	permission: Permission,
+	action: string,
+	forCustomerId?: string,
+): void => {
+	if (!hasPermission(associate, permission)) {
+		throw missingPermission(context, action, [permission], forCustomerId);
+	}
+};
+
+/**
+ * Which of a permission pair the associate holds. Used for list endpoints,
+ * where holding only the `My` variant narrows the result instead of refusing
+ * the request.
+ */
+export const viewScope = (
+	context: RepositoryContext,
+	associate: AssociateContext,
+	pair: PermissionPair,
+	action = "view",
+): AssociateScope => {
+	if (hasPermission(associate, pair[1])) {
+		return "others";
+	}
+	if (hasPermission(associate, pair[0])) {
+		return "my";
+	}
+	throw missingPermission(context, action, [pair[0], pair[1]]);
+};
+
+/** The permission an update action on a quote needs. */
+export const quoteActionPermission = (
+	action: UpdateAction,
+	scope: AssociateScope,
+): Permission | undefined => {
+	const withState = `${action.action}:${(action as { quoteState?: string }).quoteState}`;
+	const pair =
+		QUOTE_ACTION_PERMISSIONS[withState] ??
+		QUOTE_ACTION_PERMISSIONS[action.action];
+	return pair ? permissionFor(pair, scope) : undefined;
+};
+
+/** The permission an update action on a business unit needs. */
+export const businessUnitActionPermission = (
+	action: UpdateAction,
+): Permission =>
+	BUSINESS_UNIT_ACTION_PERMISSIONS[action.action] ??
+	BUSINESS_UNIT_DETAILS_PERMISSION;

--- a/src/ctMock.ts
+++ b/src/ctMock.ts
@@ -157,12 +157,12 @@ export class CommercetoolsMock {
 		// Register project routes
 		const repositories = this._repositories;
 		const oauth2 = this._oauth2;
-		const enableAuth = this.options.enableAuthentication;
 
 		const projectPlugin = async (instance: FastifyInstance) => {
-			if (enableAuth) {
-				instance.addHook("preHandler", oauth2.createMiddleware());
-			}
+			// Always installed: it resolves the identity a token was issued for,
+			// which the /me and associate-scoped endpoints need whether or not
+			// authentication is enforced
+			instance.addHook("preHandler", oauth2.createMiddleware());
 			createServices(instance, repositories);
 			new ProjectService(instance, repositories.project as ProjectRepository);
 		};
@@ -171,9 +171,7 @@ export class CommercetoolsMock {
 		// /{projectKey}/in-store/key={storeKey} are mounted there; the rest 404,
 		// as they do on the real API.
 		const inStorePlugin = async (instance: FastifyInstance) => {
-			if (enableAuth) {
-				instance.addHook("preHandler", oauth2.createMiddleware());
-			}
+			instance.addHook("preHandler", oauth2.createMiddleware());
 			createServices(instance, repositories, IN_STORE_SERVICES);
 		};
 

--- a/src/oauth/server.ts
+++ b/src/oauth/server.ts
@@ -14,6 +14,8 @@ declare module "fastify" {
 		credentials?: {
 			clientId: string;
 			clientSecret: string;
+			customerId?: string;
+			anonymousId?: string;
 		};
 	}
 }
@@ -62,50 +64,48 @@ export class OAuth2Server {
 		};
 	}
 
+	/**
+	 * Resolves who a request is for, and enforces the token when the mock is
+	 * configured to.
+	 *
+	 * Resolving the identity is not the same as requiring one: the `/me` and
+	 * associate-scoped endpoints need to know which customer a token was issued
+	 * for even when the mock is not validating credentials, so this always runs
+	 * and only the enforcement is conditional.
+	 */
 	createMiddleware() {
-		if (!this.options.validate) {
-			return async (request: FastifyRequest, reply: FastifyReply) => {
-				// When validation is disabled, still populate credentials
-				// so createdBy/lastModifiedBy can be set on resources
-				const token = getBearerToken(request);
-				const clientId = token
-					? this.store.getClientIdForToken(token)
-					: undefined;
-				request.credentials = {
-					clientId: clientId ?? "",
-					clientSecret: "",
-				};
-			};
-		}
-
 		return async (request: FastifyRequest, reply: FastifyReply) => {
 			const token = getBearerToken(request);
-			if (!token) {
-				throw new CommercetoolsError<InvalidTokenError>(
-					{
-						code: "invalid_token",
-						message:
-							"This endpoint requires an access token. You can get one from the authorization server.",
-					},
-					401,
-				);
+
+			if (this.options.validate) {
+				if (!token) {
+					throw new CommercetoolsError<InvalidTokenError>(
+						{
+							code: "invalid_token",
+							message:
+								"This endpoint requires an access token. You can get one from the authorization server.",
+						},
+						401,
+					);
+				}
+
+				if (!this.store.validateToken(token)) {
+					throw new CommercetoolsError<InvalidTokenError>(
+						{
+							code: "invalid_token",
+							message: "invalid_token",
+						},
+						401,
+					);
+				}
 			}
 
-			if (!token || !this.store.validateToken(token)) {
-				throw new CommercetoolsError<InvalidTokenError>(
-					{
-						code: "invalid_token",
-						message: "invalid_token",
-					},
-					401,
-				);
-			}
-
-			// Populate credentials so createdBy/lastModifiedBy can be set
-			const clientId = this.store.getClientIdForToken(token);
+			// Populate credentials so createdBy/lastModifiedBy can be set, and so
+			// the scoped endpoints know whose request this is
 			request.credentials = {
-				clientId: clientId ?? "",
+				clientId: token ? (this.store.getClientIdForToken(token) ?? "") : "",
 				clientSecret: "",
+				...(token ? this.store.getTokenIdentity(token) : {}),
 			};
 		};
 	}
@@ -360,11 +360,13 @@ export class OAuth2Server {
 		if (grantType === "client_credentials") {
 			const scope = query.scope?.toString() || body?.scope?.toString();
 
-			const anonymous_id = undefined;
+			// The client may bring its own anonymous id to continue a session
+			const anonymousId =
+				query.anonymous_id?.toString() || body?.anonymous_id?.toString();
 
 			const token = this.store.getAnonymousToken(
 				projectKey,
-				anonymous_id,
+				anonymousId,
 				scope,
 				request.credentials?.clientId,
 			);

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -30,6 +30,25 @@ export class OAuth2Store {
 		return this.tokenClientMap.get(accessToken);
 	}
 
+	/**
+	 * The identity a token was issued for. Customer and anonymous tokens carry
+	 * it in their scope as `customer_id:<id>` / `anonymous_id:<id>`, the way
+	 * commercetools does.
+	 */
+	getTokenIdentity(accessToken: string): {
+		customerId?: string;
+		anonymousId?: string;
+	} {
+		const token = this.tokens.find((t) => t.access_token === accessToken);
+		if (!token?.scope) {
+			return {};
+		}
+		return {
+			customerId: /(?:^|\s)customer_id:(\S+)/.exec(token.scope)?.[1],
+			anonymousId: /(?:^|\s)anonymous_id:(\S+)/.exec(token.scope)?.[1],
+		};
+	}
+
 	getClientToken(clientId: string, clientSecret: string, scope?: string) {
 		const token: Token = {
 			access_token: randomBytes(16).toString("base64"),

--- a/src/repositories/abstract.ts
+++ b/src/repositories/abstract.ts
@@ -43,6 +43,13 @@ export type RepositoryContext = {
 	projectKey: string;
 	storeKey?: string;
 	clientId?: string;
+
+	/** Set when the request carries a customer-scoped token */
+	customerId?: string;
+
+	/** Set when the request carries an anonymous-scoped token */
+	anonymousId?: string;
+
 	associateId?: string;
 	businessUnitKey?: string;
 };
@@ -132,6 +139,14 @@ export abstract class AbstractResourceRepository<
 	 */
 	get strict(): boolean {
 		return this.config.strict;
+	}
+
+	/**
+	 * The storage this repository reads from. Scoped services need it to resolve
+	 * the caller before they can decide what the caller may see.
+	 */
+	get storage(): AbstractStorage {
+		return this._storage;
 	}
 
 	abstract create(

--- a/src/repositories/cart/index.ts
+++ b/src/repositories/cart/index.ts
@@ -208,10 +208,19 @@ export class CartRepository extends AbstractResourceRepository<"cart"> {
 		return await this.saveNew(context, resource);
 	}
 
-	async getActiveCart(projectKey: string): Promise<Cart | undefined> {
-		// Get first active cart
+	async getActiveCart(
+		projectKey: string,
+		owner?: { customerId?: string; anonymousId?: string },
+	): Promise<Cart | undefined> {
+		const where = [`cartState="Active"`];
+		if (owner?.customerId) {
+			where.push(`customerId="${owner.customerId}"`);
+		} else if (owner?.anonymousId) {
+			where.push(`anonymousId="${owner.anonymousId}"`);
+		}
+
 		const results = await this._storage.query(projectKey, this.getTypeId(), {
-			where: [`cartState="Active"`],
+			where,
 		});
 		if (results.count > 0) {
 			return results.results[0] as Cart;

--- a/src/repositories/helpers.ts
+++ b/src/repositories/helpers.ts
@@ -382,6 +382,8 @@ export const getRepositoryContext = (
 	projectKey: request.params.projectKey,
 	storeKey: request.params.storeKey,
 	clientId: request.credentials?.clientId,
+	customerId: request.credentials?.customerId,
+	anonymousId: request.credentials?.anonymousId,
 	associateId: request.params.associateId,
 	businessUnitKey: request.params.businessUnitKey,
 });

--- a/src/repositories/my-customer.ts
+++ b/src/repositories/my-customer.ts
@@ -1,5 +1,6 @@
 import type {
 	Customer,
+	InsufficientScopeError,
 	InvalidCurrentPasswordError,
 	MyCustomerChangePassword,
 	MyCustomerEmailVerify,
@@ -10,6 +11,24 @@ import { hashPassword, validateEmailVerifyToken } from "../lib/password.ts";
 import type { Writable } from "../types.ts";
 import type { RepositoryContext } from "./abstract.ts";
 import { CustomerRepository } from "./customer/index.ts";
+
+/**
+ * `/me` answers for the customer the token was issued to. Without one there is
+ * no answer to give, so the request is refused rather than served with whichever
+ * customer happens to be stored first.
+ */
+const requireCustomerId = (context: RepositoryContext): string => {
+	if (!context.customerId) {
+		throw new CommercetoolsError<InsufficientScopeError>(
+			{
+				code: "insufficient_scope",
+				message: "This endpoint requires a token issued for a customer.",
+			},
+			403,
+		);
+	}
+	return context.customerId;
+};
 
 export class MyCustomerRepository extends CustomerRepository {
 	async changePassword(
@@ -81,35 +100,17 @@ export class MyCustomerRepository extends CustomerRepository {
 	}
 
 	async deleteMe(context: RepositoryContext): Promise<Customer | undefined> {
-		// grab the first customer you can find for now. In the future we should
-		// use the customer id from the scope of the token
-		const results = await this._storage.query(
-			context.projectKey,
-			this.getTypeId(),
-			{},
-		);
-
-		if (results.count > 0) {
-			const deleted = await this.delete(context, results.results[0].id);
-			return deleted as Customer;
-		}
-
-		return;
+		const customerId = requireCustomerId(context);
+		const deleted = await this.delete(context, customerId);
+		return deleted as Customer | undefined;
 	}
 
 	async getMe(context: RepositoryContext): Promise<Customer | undefined> {
-		// grab the first customer you can find for now. In the future we should
-		// use the customer id from the scope of the token
-		const results = await this._storage.query(
+		const customerId = requireCustomerId(context);
+		return (await this._storage.get(
 			context.projectKey,
-			this.getTypeId(),
-			{},
-		);
-
-		if (results.count > 0) {
-			return results.results[0] as Customer;
-		}
-
-		return;
+			"customer",
+			customerId,
+		)) as Customer | undefined;
 	}
 }

--- a/src/repositories/order/index.ts
+++ b/src/repositories/order/index.ts
@@ -105,6 +105,7 @@ export class OrderRepository extends AbstractResourceRepository<"order"> {
 			...getBaseResourceProperties(context.clientId),
 			anonymousId: cart.anonymousId,
 			billingAddress: cart.billingAddress,
+			businessUnit: cart.businessUnit,
 			cart: cartReference,
 			country: cart.country,
 			custom: cart.custom,

--- a/src/repositories/payment/index.ts
+++ b/src/repositories/payment/index.ts
@@ -1,4 +1,5 @@
 import type {
+	CustomerReference,
 	Payment,
 	PaymentDraft,
 	StateReference,
@@ -46,6 +47,14 @@ export class PaymentRepository extends AbstractResourceRepository<"payment"> {
 		const resource: Payment = {
 			...getBaseResourceProperties(context.clientId),
 			key: draft.key,
+			customer: draft.customer
+				? await getReferenceFromResourceIdentifier<CustomerReference>(
+						draft.customer,
+						context.projectKey,
+						this._storage,
+					)
+				: undefined,
+			anonymousId: draft.anonymousId,
 			amountPlanned: createCentPrecisionMoney(draft.amountPlanned),
 			paymentMethodInfo: { ...draft.paymentMethodInfo!, custom: undefined },
 			paymentStatus: draft.paymentStatus

--- a/src/repositories/quote-request/index.ts
+++ b/src/repositories/quote-request/index.ts
@@ -73,6 +73,7 @@ export class QuoteRequestRepository extends AbstractResourceRepository<"quote-re
 		const resource: QuoteRequest = {
 			...getBaseResourceProperties(context.clientId),
 			billingAddress: cart.billingAddress,
+			businessUnit: cart.businessUnit,
 			cart: cartReference,
 			country: cart.country,
 			custom: cart.custom,

--- a/src/services/abstract-associate.ts
+++ b/src/services/abstract-associate.ts
@@ -1,0 +1,260 @@
+import type {
+	Permission,
+	ResourceNotFoundError,
+	UpdateAction,
+} from "@commercetools/platform-sdk";
+import type { FastifyRequest } from "fastify";
+import {
+	type AssociateContext,
+	type AssociateScope,
+	type PermissionPair,
+	permissionFor,
+	requirePermission,
+	resolveAssociateContext,
+	viewScope,
+} from "#src/associate-permissions.ts";
+import { CommercetoolsError } from "#src/exceptions.ts";
+import { getRepositoryContext } from "#src/repositories/helpers.ts";
+import AbstractService from "./abstract.ts";
+
+type ScopedRequest = FastifyRequest<{ Params: Record<string, string> }>;
+
+/**
+ * What a resource needs to declare for the associate scope to police it.
+ *
+ * The predicates are applied to list requests, so a caller never receives a
+ * page that was filtered afterwards; the accessors answer the same questions
+ * for a single resource that was resolved by id or key.
+ */
+export type AssociateResourceRules = {
+	/** Permission pair for reading. Omit when any associate of the unit may read. */
+	view?: PermissionPair;
+	create?: PermissionPair;
+	update?: PermissionPair;
+	delete?: PermissionPair;
+
+	/** Predicate limiting a query to the business unit named in the path. */
+	businessUnitWhere?: (key: string) => string;
+
+	/** Predicate limiting a query to the acting associate's own resources. */
+	ownerWhere?: (associateId: string) => string;
+
+	/** The customer a stored resource belongs to. */
+	ownerOf?: (resource: any) => string | undefined;
+
+	/** The business unit a stored resource belongs to. */
+	businessUnitOf?: (resource: any) => string | undefined;
+
+	/**
+	 * The permission a single update action needs, for resources where that
+	 * depends on the action rather than on a blanket update permission.
+	 */
+	actionPermission?: (
+		action: UpdateAction,
+		scope: AssociateScope,
+	) => Permission | undefined;
+
+	/** Permission for creating, when it does not depend on who owns the draft. */
+	createPermission?: Permission;
+
+	/** The customer a create draft is for, to tell `My` from `Others`. */
+	ownerOfDraft?: (draft: any) => string | undefined;
+
+	/**
+	 * Stamps the scope onto a create draft. Without it a resource created
+	 * through the associate scope would fall outside the scope that created it.
+	 */
+	stampDraft?: (
+		draft: any,
+		scope: { associateId: string; businessUnitKey: string },
+	) => any;
+};
+
+/**
+ * Base for the `as-associate` services: resolves the associate named in the
+ * path, then refuses anything their AssociateRoles do not allow.
+ */
+export default abstract class AbstractAssociateService extends AbstractService {
+	protected abstract rules: AssociateResourceRules;
+
+	protected async associateContext(
+		request: ScopedRequest,
+	): Promise<AssociateContext> {
+		return resolveAssociateContext(
+			getRepositoryContext(request),
+			this.repository.storage,
+		);
+	}
+
+	protected scopeOf(
+		request: ScopedRequest,
+		associate: AssociateContext,
+		resource: unknown,
+	): AssociateScope {
+		const owner = this.rules.ownerOf?.(resource);
+		return owner && owner === associate.associateId ? "my" : "others";
+	}
+
+	protected override async scopeWhere(
+		request: ScopedRequest,
+	): Promise<string[]> {
+		const context = getRepositoryContext(request);
+		const associate = await this.associateContext(request);
+		const where: string[] = [];
+
+		if (this.rules.businessUnitWhere && context.businessUnitKey) {
+			where.push(this.rules.businessUnitWhere(context.businessUnitKey));
+		}
+
+		if (this.rules.view) {
+			const scope = viewScope(context, associate, this.rules.view);
+			if (scope === "my" && this.rules.ownerWhere) {
+				where.push(this.rules.ownerWhere(associate.associateId));
+			}
+		}
+
+		return where;
+	}
+
+	protected override async authorizeResource(
+		request: ScopedRequest,
+		operation: "view" | "update" | "delete",
+		resource: unknown,
+	): Promise<void> {
+		const context = getRepositoryContext(request);
+		const associate = await this.associateContext(request);
+
+		// A resource of another business unit is not visible here at all
+		const businessUnitKey = this.rules.businessUnitOf?.(resource);
+		if (
+			this.rules.businessUnitOf &&
+			businessUnitKey !== context.businessUnitKey
+		) {
+			this.throwNotFound(request);
+		}
+
+		const scope = this.scopeOf(request, associate, resource);
+		const owner = this.rules.ownerOf?.(resource);
+
+		if (operation === "view") {
+			if (this.rules.view) {
+				requirePermission(
+					context,
+					associate,
+					permissionFor(this.rules.view, scope),
+					"view",
+					owner,
+				);
+			}
+			return;
+		}
+
+		if (operation === "delete") {
+			if (this.rules.delete) {
+				requirePermission(
+					context,
+					associate,
+					permissionFor(this.rules.delete, scope),
+					"delete",
+					owner,
+				);
+			}
+			return;
+		}
+
+		await this.authorizeUpdate(request, associate, scope, resource, owner);
+	}
+
+	protected async authorizeUpdate(
+		request: ScopedRequest,
+		associate: AssociateContext,
+		scope: AssociateScope,
+		_resource: unknown,
+		owner: string | undefined,
+	): Promise<void> {
+		const context = getRepositoryContext(request);
+
+		if (this.rules.update) {
+			requirePermission(
+				context,
+				associate,
+				permissionFor(this.rules.update, scope),
+				"update",
+				owner,
+			);
+			return;
+		}
+
+		if (!this.rules.actionPermission) {
+			return;
+		}
+
+		// Resources without a blanket update permission are policed per action
+		const actions = (request.body as { actions?: UpdateAction[] })?.actions;
+		for (const action of actions ?? []) {
+			const permission = this.rules.actionPermission(action, scope);
+			if (permission) {
+				requirePermission(context, associate, permission, action.action, owner);
+			} else if (this.rules.view) {
+				requirePermission(
+					context,
+					associate,
+					permissionFor(this.rules.view, scope),
+					action.action,
+					owner,
+				);
+			}
+		}
+	}
+
+	protected override async authorizeCreate(
+		request: ScopedRequest,
+		draft: unknown,
+	): Promise<unknown> {
+		const context = getRepositoryContext(request);
+		const associate = await this.associateContext(request);
+
+		if (this.rules.createPermission) {
+			requirePermission(
+				context,
+				associate,
+				this.rules.createPermission,
+				"create",
+			);
+		} else if (this.rules.create) {
+			const owner = this.rules.ownerOfDraft?.(draft);
+			const scope: AssociateScope =
+				owner === undefined || owner === associate.associateId
+					? "my"
+					: "others";
+			requirePermission(
+				context,
+				associate,
+				permissionFor(this.rules.create, scope),
+				"create",
+				owner,
+			);
+		}
+
+		if (this.rules.stampDraft && context.businessUnitKey) {
+			return this.rules.stampDraft(draft, {
+				associateId: associate.associateId,
+				businessUnitKey: context.businessUnitKey,
+			});
+		}
+		return draft;
+	}
+
+	private throwNotFound(request: ScopedRequest): never {
+		const { id, key } = request.params;
+		throw new CommercetoolsError<ResourceNotFoundError>(
+			{
+				code: "ResourceNotFound",
+				message: id
+					? `The Resource with ID '${id}' was not found.`
+					: `The Resource with key '${key}' was not found.`,
+			},
+			404,
+		);
+	}
+}

--- a/src/services/abstract-my.ts
+++ b/src/services/abstract-my.ts
@@ -1,0 +1,118 @@
+import type {
+	InsufficientScopeError,
+	ResourceNotFoundError,
+} from "@commercetools/platform-sdk";
+import type { FastifyRequest } from "fastify";
+import { CommercetoolsError } from "#src/exceptions.ts";
+import type { RepositoryContext } from "#src/repositories/abstract.ts";
+import { getRepositoryContext } from "#src/repositories/helpers.ts";
+import AbstractService from "./abstract.ts";
+
+type ScopedRequest = FastifyRequest<{ Params: Record<string, string> }>;
+
+export type MyIdentity =
+	| { type: "customer"; id: string }
+	| { type: "anonymous"; id: string };
+
+/**
+ * What a `/me` resource needs to declare so the endpoint can be scoped to the
+ * caller.
+ */
+export type MyResourceRules = {
+	/** Predicate limiting a query to the customer the token was issued for. */
+	customerWhere: (customerId: string) => string;
+
+	/** Predicate limiting a query to the anonymous session, when supported. */
+	anonymousWhere?: (anonymousId: string) => string;
+
+	/** The customer a stored resource belongs to. */
+	customerOf: (resource: any) => string | undefined;
+
+	/** The anonymous session a stored resource belongs to. */
+	anonymousOf?: (resource: any) => string | undefined;
+
+	/** Stamps the caller onto a create draft, so they can read it back. */
+	stampDraft?: (draft: any, identity: MyIdentity) => any;
+};
+
+/**
+ * Base for the `/me` services.
+ *
+ * The `/me` endpoints answer for whoever the token was issued to, so a request
+ * without a customer or anonymous token has no answer to give. It is refused
+ * rather than served from the whole collection: returning another customer's
+ * order to an unauthenticated caller turns an ownership test into one that
+ * passes without asserting anything.
+ */
+export default abstract class AbstractMyService extends AbstractService {
+	protected abstract myRules: MyResourceRules;
+
+	protected identityOf(context: RepositoryContext): MyIdentity {
+		if (context.customerId) {
+			return { type: "customer", id: context.customerId };
+		}
+		if (context.anonymousId && this.myRules.anonymousWhere) {
+			return { type: "anonymous", id: context.anonymousId };
+		}
+
+		throw new CommercetoolsError<InsufficientScopeError>(
+			{
+				code: "insufficient_scope",
+				message:
+					"This endpoint requires a token issued for a customer or an anonymous session.",
+			},
+			403,
+		);
+	}
+
+	protected owns(identity: MyIdentity, resource: unknown): boolean {
+		if (identity.type === "customer") {
+			return this.myRules.customerOf(resource) === identity.id;
+		}
+		return this.myRules.anonymousOf?.(resource) === identity.id;
+	}
+
+	protected override async scopeWhere(
+		request: ScopedRequest,
+	): Promise<string[]> {
+		const identity = this.identityOf(getRepositoryContext(request));
+		return [
+			identity.type === "customer"
+				? this.myRules.customerWhere(identity.id)
+				: // biome-ignore lint/style/noNonNullAssertion: identityOf only
+					// returns an anonymous identity when the predicate exists
+					this.myRules.anonymousWhere!(identity.id),
+		];
+	}
+
+	protected override async authorizeResource(
+		request: ScopedRequest,
+		_operation: "view" | "update" | "delete",
+		resource: unknown,
+	): Promise<void> {
+		const identity = this.identityOf(getRepositoryContext(request));
+		if (this.owns(identity, resource)) {
+			return;
+		}
+
+		// Someone else's resource does not exist as far as /me is concerned
+		const { id, key } = request.params;
+		throw new CommercetoolsError<ResourceNotFoundError>(
+			{
+				code: "ResourceNotFound",
+				message: id
+					? `The Resource with ID '${id}' was not found.`
+					: `The Resource with key '${key}' was not found.`,
+			},
+			404,
+		);
+	}
+
+	protected override async authorizeCreate(
+		request: ScopedRequest,
+		draft: unknown,
+	): Promise<unknown> {
+		const identity = this.identityOf(getRepositoryContext(request));
+		return this.myRules.stampDraft?.(draft, identity) ?? draft;
+	}
+}

--- a/src/services/abstract.ts
+++ b/src/services/abstract.ts
@@ -27,6 +27,38 @@ export default abstract class AbstractService {
 
 	extraRoutes(instance: FastifyInstance) {}
 
+	/**
+	 * Extra predicates to narrow a list request to what the caller may see.
+	 * Empty for the unscoped endpoints; the `/me` and associate-scoped services
+	 * override it.
+	 */
+	protected async scopeWhere(
+		_request: FastifyRequest<{ Params: Record<string, string> }>,
+	): Promise<string[]> {
+		return [];
+	}
+
+	/**
+	 * Called with a resource that was resolved by id or key, before it is
+	 * returned or modified. Throws when the caller may not touch it.
+	 */
+	protected async authorizeResource(
+		_request: FastifyRequest<{ Params: Record<string, string> }>,
+		_operation: "view" | "update" | "delete",
+		_resource: unknown,
+	): Promise<void> {}
+
+	/**
+	 * Called with the draft of a create request. Returns the draft to store, so
+	 * a scoped endpoint can stamp the identity it is scoped to onto it.
+	 */
+	protected async authorizeCreate(
+		_request: FastifyRequest<{ Params: Record<string, string> }>,
+		draft: unknown,
+	): Promise<unknown> {
+		return draft;
+	}
+
 	registerRoutes(parent: FastifyInstance) {
 		const basePath = this.getBasePath();
 		parent.register(
@@ -60,9 +92,10 @@ export default abstract class AbstractService {
 		const query = request.query;
 		const limit = this._parseParam(query.limit);
 		const offset = this._parseParam(query.offset);
+		const scoped = await this.scopeWhere(request);
 		const params: QueryParams = {
 			expand: this._parseParam(query.expand),
-			where: this._parseParam(query.where),
+			where: [...(this._parseParam(query.where) ?? []), ...scoped],
 			limit: limit !== undefined ? Number(limit) : undefined,
 			offset: offset !== undefined ? Number(offset) : undefined,
 		};
@@ -101,6 +134,7 @@ export default abstract class AbstractService {
 				404,
 			);
 		}
+		await this.authorizeResource(request, "view", result);
 		return reply.status(200).send(result);
 	}
 
@@ -129,6 +163,7 @@ export default abstract class AbstractService {
 				404,
 			);
 		}
+		await this.authorizeResource(request, "view", result);
 		return reply.status(200).send(result);
 	}
 
@@ -141,6 +176,13 @@ export default abstract class AbstractService {
 	) {
 		const params = request.params;
 		const query = request.query;
+		const current = await this.repository.get(
+			getRepositoryContext(request),
+			params.id,
+		);
+		if (current) {
+			await this.authorizeResource(request, "delete", current);
+		}
 		const result = await this.repository.delete(
 			getRepositoryContext(request),
 			params.id,
@@ -183,6 +225,8 @@ export default abstract class AbstractService {
 			);
 		}
 
+		await this.authorizeResource(request, "delete", resource);
+
 		const result = await this.repository.delete(
 			getRepositoryContext(request),
 			resource.id,
@@ -214,9 +258,11 @@ export default abstract class AbstractService {
 			validateDraft(request.body, this.repository.draftSchema);
 		}
 
+		const draft = await this.authorizeCreate(request, request.body);
+
 		const resource = await this.repository.create(
 			getRepositoryContext(request),
-			request.body,
+			draft,
 		);
 
 		const query = request.query;
@@ -260,6 +306,8 @@ export default abstract class AbstractService {
 			);
 		}
 
+		await this.authorizeResource(request, "update", resource);
+
 		const updatedResource = await this.repository.processUpdateActions(
 			getRepositoryContext(request),
 			resource,
@@ -297,6 +345,8 @@ export default abstract class AbstractService {
 				404,
 			);
 		}
+
+		await this.authorizeResource(request, "update", resource);
 
 		const updatedResource = await this.repository.processUpdateActions(
 			getRepositoryContext(request),

--- a/src/services/as-associate-approval-flow.ts
+++ b/src/services/as-associate-approval-flow.ts
@@ -1,9 +1,20 @@
 import type { FastifyInstance } from "fastify";
+import { APPROVAL_FLOW_UPDATE_PERMISSION } from "#src/associate-permissions.ts";
 import type { AsAssociateApprovalFlowRepository } from "#src/repositories/as-associate.ts";
-import AbstractService from "./abstract.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateApprovalFlowService extends AbstractService {
+export class AsAssociateApprovalFlowService extends AbstractAssociateService {
 	public repository: AsAssociateApprovalFlowRepository;
+
+	// Approval flows have no view permission of their own: any associate of the
+	// business unit may read them, and only updating is guarded
+	protected rules: AssociateResourceRules = {
+		update: [APPROVAL_FLOW_UPDATE_PERMISSION, APPROVAL_FLOW_UPDATE_PERMISSION],
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		businessUnitOf: (flow) => flow.businessUnit?.key,
+	};
 
 	constructor(
 		parent: FastifyInstance,
@@ -15,22 +26,5 @@ export class AsAssociateApprovalFlowService extends AbstractService {
 
 	getBasePath() {
 		return "approval-flows";
-	}
-
-	registerRoutes(parent: FastifyInstance) {
-		const basePath = this.getBasePath();
-		parent.register(
-			(instance, opts, done) => {
-				this.extraRoutes(instance);
-
-				instance.get("/", this.get.bind(this));
-				instance.get("/:id", this.getWithId.bind(this));
-
-				instance.post("/:id", this.postWithId.bind(this));
-
-				done();
-			},
-			{ prefix: `/${basePath}` },
-		);
 	}
 }

--- a/src/services/as-associate-approval-rule.ts
+++ b/src/services/as-associate-approval-rule.ts
@@ -1,9 +1,29 @@
 import type { FastifyInstance } from "fastify";
+import {
+	APPROVAL_RULE_CREATE_PERMISSION,
+	APPROVAL_RULE_UPDATE_PERMISSION,
+} from "#src/associate-permissions.ts";
 import type { AsAssociateApprovalRuleRepository } from "#src/repositories/as-associate.ts";
-import AbstractService from "./abstract.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateApprovalRuleService extends AbstractService {
+export class AsAssociateApprovalRuleService extends AbstractAssociateService {
 	public repository: AsAssociateApprovalRuleRepository;
+
+	protected rules: AssociateResourceRules = {
+		update: [APPROVAL_RULE_UPDATE_PERMISSION, APPROVAL_RULE_UPDATE_PERMISSION],
+		createPermission: APPROVAL_RULE_CREATE_PERMISSION,
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		businessUnitOf: (rule) => rule.businessUnit?.key,
+		stampDraft: (draft, scope) => ({
+			...draft,
+			businessUnit: draft.businessUnit ?? {
+				typeId: "business-unit",
+				key: scope.businessUnitKey,
+			},
+		}),
+	};
 
 	constructor(
 		parent: FastifyInstance,

--- a/src/services/as-associate-business-unit.test.ts
+++ b/src/services/as-associate-business-unit.test.ts
@@ -1,70 +1,108 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { businessUnitDraftFactory } from "#src/testing/business-unit.ts";
+import { createAssociateScope } from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
 const projectKey = "dummy";
-const associateId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
 
 describe("AsAssociateBusinessUnit", () => {
-	const businessUnitFactory = businessUnitDraftFactory(ctMock);
-
 	afterEach(async () => {
 		await ctMock.clear();
 	});
 
 	test("Get business units as associate", async () => {
-		await businessUnitFactory.create({
-			key: "as-associate-bu",
-			unitType: "Company",
-			name: "As Associate BU",
-			contactEmail: "contact@example.com",
-		});
+		const scope = await createAssociateScope(ctMock);
+		// A unit the associate has nothing to do with
+		await createAssociateScope(ctMock);
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${associateId}/business-units`,
+			url: `/${projectKey}/as-associate/${scope.associateId}/business-units`,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json().results).toBeDefined();
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].key).toBe(scope.businessUnitKey);
 	});
 
 	test("Get business unit by key as associate", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "as-associate-bu",
-			unitType: "Company",
-			name: "As Associate BU",
-			contactEmail: "contact@example.com",
-		});
+		const scope = await createAssociateScope(ctMock);
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${associateId}/business-units/key=${businessUnit.key}`,
+			url: `/${projectKey}/as-associate/${scope.associateId}/business-units/key=${scope.businessUnitKey}`,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual(businessUnit);
+		expect(response.json().key).toBe(scope.businessUnitKey);
 	});
 
-	test("Update business unit by key as associate", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "as-associate-bu",
-			unitType: "Company",
-			name: "As Associate BU",
-			contactEmail: "contact@example.com",
+	test("Get a business unit the caller is not an associate of", async () => {
+		const scope = await createAssociateScope(ctMock);
+		const other = await createAssociateScope(ctMock);
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/${projectKey}/as-associate/${scope.associateId}/business-units/key=${other.businessUnitKey}`,
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("AssociateMissingPermission");
+	});
+
+	test("Update business unit details", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["UpdateBusinessUnitDetails"],
 		});
 
 		const response = await ctMock.app.inject({
 			method: "POST",
-			url: `/${projectKey}/as-associate/${associateId}/business-units/key=${businessUnit.key}`,
+			url: `/${projectKey}/as-associate/${scope.associateId}/business-units/key=${scope.businessUnitKey}`,
 			payload: {
-				version: businessUnit.version,
+				version: 1,
 				actions: [{ action: "changeName", name: "Updated Name" }],
 			},
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json().name).toBe("Updated Name");
+	});
+
+	test("Update business unit details without the permission", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["UpdateAssociates"],
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/${projectKey}/as-associate/${scope.associateId}/business-units/key=${scope.businessUnitKey}`,
+			payload: {
+				version: 1,
+				actions: [{ action: "changeName", name: "Updated Name" }],
+			},
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual([
+			"UpdateBusinessUnitDetails",
+		]);
+	});
+
+	test("Changing associates needs UpdateAssociates", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["UpdateBusinessUnitDetails"],
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `/${projectKey}/as-associate/${scope.associateId}/business-units/key=${scope.businessUnitKey}`,
+			payload: {
+				version: 1,
+				actions: [{ action: "setAssociates", associates: [] }],
+			},
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual(["UpdateAssociates"]);
 	});
 });

--- a/src/services/as-associate-business-unit.ts
+++ b/src/services/as-associate-business-unit.ts
@@ -1,7 +1,23 @@
-import type { FastifyInstance } from "fastify";
+import type { UpdateAction } from "@commercetools/platform-sdk";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import {
+	BUSINESS_UNIT_CREATE_PERMISSION,
+	businessUnitActionPermission,
+	requirePermission,
+	resolveAssociateContext,
+} from "#src/associate-permissions.ts";
 import type { AsAssociateBusinessUnitRepository } from "#src/repositories/as-associate.ts";
+import { getRepositoryContext } from "#src/repositories/helpers.ts";
 import AbstractService from "./abstract.ts";
 
+type ScopedRequest = FastifyRequest<{ Params: Record<string, string> }>;
+
+/**
+ * `/as-associate/{associateId}/business-units` is the one associate-scoped
+ * resource that does not sit inside `in-business-unit/key=`: it lists the units
+ * the associate belongs to. So the unit to check permissions against comes from
+ * the resource, not from the path.
+ */
 export class AsAssociateBusinessUnitService extends AbstractService {
 	public repository: AsAssociateBusinessUnitRepository;
 
@@ -15,5 +31,65 @@ export class AsAssociateBusinessUnitService extends AbstractService {
 
 	getBasePath() {
 		return "business-units";
+	}
+
+	protected override async scopeWhere(
+		request: ScopedRequest,
+	): Promise<string[]> {
+		const { associateId } = getRepositoryContext(request);
+		return associateId ? [`associates(customer(id="${associateId}"))`] : [];
+	}
+
+	protected override async authorizeResource(
+		request: ScopedRequest,
+		operation: "view" | "update" | "delete",
+		resource: unknown,
+	): Promise<void> {
+		const context = getRepositoryContext(request);
+		const businessUnit = resource as { key: string };
+
+		// Resolving throws when the caller is not an associate of this unit
+		const associate = await resolveAssociateContext(
+			context,
+			this.repository.storage,
+			businessUnit.key,
+		);
+
+		if (operation === "view") {
+			return;
+		}
+
+		const actions =
+			(request.body as { actions?: UpdateAction[] })?.actions ?? [];
+		for (const action of actions) {
+			requirePermission(
+				context,
+				associate,
+				businessUnitActionPermission(action),
+				action.action,
+			);
+		}
+	}
+
+	protected override async authorizeCreate(
+		request: ScopedRequest,
+		draft: unknown,
+	): Promise<unknown> {
+		const context = getRepositoryContext(request);
+		const parentUnit = (draft as { parentUnit?: { key?: string } }).parentUnit;
+
+		const associate = await resolveAssociateContext(
+			context,
+			this.repository.storage,
+			parentUnit?.key,
+		);
+		requirePermission(
+			context,
+			associate,
+			BUSINESS_UNIT_CREATE_PERMISSION,
+			"create",
+		);
+
+		return draft;
 	}
 }

--- a/src/services/as-associate-cart.test.ts
+++ b/src/services/as-associate-cart.test.ts
@@ -1,50 +1,196 @@
-import { describe, expect, test } from "vitest";
-import { cartDraftFactory } from "#src/testing/index.ts";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	cartDraftFactory,
+	createAssociateScope,
+	customerDraftFactory,
+} from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
-const projectKey = "dummy";
-const customerId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
-const businessUnitKey = "test-business-unit";
 
 describe("AsAssociateCart", () => {
 	const factory = cartDraftFactory(ctMock);
 
+	const colleagueId = async () =>
+		(await customerDraftFactory(ctMock).create()).id;
+
+	afterEach(async () => {
+		await ctMock.clear();
+	});
+
 	test("Create cart", async () => {
-		const draft = factory.build({ currency: "EUR" });
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["CreateMyCarts", "ViewMyCarts"],
+		});
 
 		const response = await ctMock.app.inject({
 			method: "POST",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/carts`,
-			payload: draft,
+			url: `${scope.basePath}/carts`,
+			payload: factory.build({ currency: "EUR" }),
 		});
 
 		expect(response.statusCode).toBe(201);
-		const cart = response.json();
-		expect(cart.id).toBeDefined();
+
+		// The cart is stamped with the scope that created it, so it stays visible
+		// to that scope
+		expect(response.json().customerId).toBe(scope.associateId);
+		expect(response.json().businessUnit).toEqual({
+			typeId: "business-unit",
+			key: scope.businessUnitKey,
+		});
 	});
 
-	test("Get cart", async () => {
-		const cart = await factory.create({ currency: "USD" });
+	test("Create cart without the permission", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyCarts"],
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/carts`,
+			payload: factory.build({ currency: "EUR" }),
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("AssociateMissingPermission");
+		expect(response.json().errors[0].permissions).toEqual(["CreateMyCarts"]);
+	});
+
+	test("Get own cart", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["CreateMyCarts", "ViewMyCarts"],
+		});
+
+		const created = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/carts`,
+			payload: factory.build({ currency: "EUR" }),
+		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/carts/${cart.id}`,
+			url: `${scope.basePath}/carts/${created.json().id}`,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual(cart);
+		expect(response.json().id).toBe(created.json().id);
 	});
 
-	test("Query carts", async () => {
-		await factory.create({ currency: "GBP" });
+	test("Get a colleague's cart needs ViewOthersCarts", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyCarts"],
+		});
+
+		const colleagueCart = await factory.create({
+			currency: "EUR",
+			customerId: await colleagueId(),
+			businessUnit: {
+				typeId: "business-unit",
+				key: scope.businessUnitKey,
+			},
+		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/carts`,
+			url: `${scope.basePath}/carts/${colleagueCart.id}`,
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual(["ViewOthersCarts"]);
+	});
+
+	test("Query carts is narrowed to the caller with only ViewMyCarts", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyCarts"],
+		});
+
+		const own = await factory.create({
+			currency: "EUR",
+			customerId: scope.associateId,
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
+		});
+		await factory.create({
+			currency: "EUR",
+			customerId: await colleagueId(),
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
+		});
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${scope.basePath}/carts`,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json().count).toBeGreaterThan(0);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].id).toBe(own.id);
+	});
+
+	test("Query carts covers the unit with ViewOthersCarts", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewOthersCarts"],
+		});
+
+		await factory.create({
+			currency: "EUR",
+			customerId: scope.associateId,
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
+		});
+		await factory.create({
+			currency: "EUR",
+			customerId: await colleagueId(),
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
+		});
+		// A cart of another business unit is never in scope
+		await factory.create({ currency: "EUR" });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${scope.basePath}/carts`,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().results).toHaveLength(2);
+	});
+
+	test("Query carts without a view permission", async () => {
+		const scope = await createAssociateScope(ctMock, { permissions: [] });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${scope.basePath}/carts`,
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual([
+			"ViewMyCarts",
+			"ViewOthersCarts",
+		]);
+	});
+
+	test("A customer who is not an associate of the unit", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewOthersCarts"],
+		});
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/as-associate/1e6b4d5f-0a3c-4c2e-9d7a-8b5c6d7e8f90/in-business-unit/key=${scope.businessUnitKey}/carts`,
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("AssociateMissingPermission");
+	});
+
+	test("An unknown business unit", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewOthersCarts"],
+		});
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/as-associate/${scope.associateId}/in-business-unit/key=does-not-exist/carts`,
+		});
+
+		expect(response.statusCode).toBe(404);
 	});
 });

--- a/src/services/as-associate-cart.ts
+++ b/src/services/as-associate-cart.ts
@@ -1,36 +1,39 @@
 import type { FastifyInstance } from "fastify";
-import type { CartRepository } from "../repositories/cart/index.ts";
-import AbstractService from "./abstract.ts";
+import { CART_PERMISSIONS } from "#src/associate-permissions.ts";
+import type { AsAssociateCartRepository } from "#src/repositories/as-associate.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateCartService extends AbstractService {
-	public repository: CartRepository;
+export class AsAssociateCartService extends AbstractAssociateService {
+	public repository: AsAssociateCartRepository;
 
-	constructor(parent: FastifyInstance, repository: CartRepository) {
+	protected rules: AssociateResourceRules = {
+		view: CART_PERMISSIONS.view,
+		create: CART_PERMISSIONS.create,
+		update: CART_PERMISSIONS.update,
+		delete: CART_PERMISSIONS.delete,
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		ownerWhere: (associateId) => `customerId="${associateId}"`,
+		ownerOf: (cart) => cart.customerId,
+		businessUnitOf: (cart) => cart.businessUnit?.key,
+		ownerOfDraft: (draft) => draft.customerId,
+		stampDraft: (draft, scope) => ({
+			...draft,
+			customerId: draft.customerId ?? scope.associateId,
+			businessUnit: draft.businessUnit ?? {
+				typeId: "business-unit",
+				key: scope.businessUnitKey,
+			},
+		}),
+	};
+
+	constructor(parent: FastifyInstance, repository: AsAssociateCartRepository) {
 		super(parent);
 		this.repository = repository;
 	}
 
 	getBasePath() {
 		return "carts";
-	}
-
-	registerRoutes(parent: FastifyInstance) {
-		const basePath = this.getBasePath();
-		parent.register(
-			(instance, opts, done) => {
-				this.extraRoutes(instance);
-
-				instance.get("/", this.get.bind(this));
-				instance.get("/:id", this.getWithId.bind(this));
-
-				instance.delete("/:id", this.deleteWithId.bind(this));
-
-				instance.post("/", this.post.bind(this));
-				instance.post("/:id", this.postWithId.bind(this));
-
-				done();
-			},
-			{ prefix: `/${basePath}` },
-		);
 	}
 }

--- a/src/services/as-associate-order.test.ts
+++ b/src/services/as-associate-order.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert";
 import type { Order } from "@commercetools/platform-sdk";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { cartDraftFactory, orderDraftFactory } from "#src/testing/index.ts";
+import {
+	cartDraftFactory,
+	createAssociateScope,
+	orderDraftFactory,
+} from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 describe("Order Query", () => {
@@ -9,13 +13,17 @@ describe("Order Query", () => {
 	const cartFactory = cartDraftFactory(ctMock);
 	const orderFactory = orderDraftFactory(ctMock);
 	let order: Order | undefined;
-	const projectKey = "dummy";
-	const customerId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
-	const businessUnitKey = "business-unit";
+	let scope: Awaited<ReturnType<typeof createAssociateScope>>;
 
 	beforeEach(async () => {
+		scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyOrders"],
+		});
+
 		const cart = await cartFactory.create({
 			currency: "EUR",
+			customerId: scope.associateId,
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
 			custom: {
 				type: {
 					key: "my-cart",
@@ -45,7 +53,7 @@ describe("Order Query", () => {
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/orders`,
+			url: `${scope.basePath}/orders`,
 		});
 		expect(response.statusCode).toBe(200);
 		const body = response.json();

--- a/src/services/as-associate-order.ts
+++ b/src/services/as-associate-order.ts
@@ -1,17 +1,70 @@
-import type { FastifyInstance } from "fastify";
-import type { MyOrderRepository } from "../repositories/my-order.ts";
-import AbstractService from "./abstract.ts";
+import type { Cart } from "@commercetools/platform-sdk";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import {
+	ORDER_PERMISSIONS,
+	permissionFor,
+	requirePermission,
+} from "#src/associate-permissions.ts";
+import type { AsAssociateOrderRepository } from "#src/repositories/as-associate.ts";
+import { getRepositoryContext } from "#src/repositories/helpers.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateOrderService extends AbstractService {
-	public repository: MyOrderRepository;
+export class AsAssociateOrderService extends AbstractAssociateService {
+	public repository: AsAssociateOrderRepository;
 
-	constructor(parent: FastifyInstance, repository: MyOrderRepository) {
+	protected rules: AssociateResourceRules = {
+		view: ORDER_PERMISSIONS.view,
+		update: ORDER_PERMISSIONS.update,
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		ownerWhere: (associateId) => `customerId="${associateId}"`,
+		ownerOf: (order) => order.customerId,
+		businessUnitOf: (order) => order.businessUnit?.key,
+	};
+
+	constructor(parent: FastifyInstance, repository: AsAssociateOrderRepository) {
 		super(parent);
 		this.repository = repository;
 	}
 
 	getBasePath() {
 		return "orders";
+	}
+
+	/**
+	 * An order is created from a cart, so whether this is `My` or `Others` is
+	 * decided by who owns that cart rather than by anything in the draft.
+	 */
+	protected override async authorizeCreate(
+		request: FastifyRequest<{ Params: Record<string, string> }>,
+		draft: unknown,
+	): Promise<unknown> {
+		const context = getRepositoryContext(request);
+		const associate = await this.associateContext(request);
+
+		const cartId = (draft as { cart?: { id?: string } }).cart?.id;
+		const cart = cartId
+			? ((await this.repository.storage.get(
+					context.projectKey,
+					"cart",
+					cartId,
+				)) as Cart | null)
+			: null;
+
+		const owner = cart?.customerId;
+		requirePermission(
+			context,
+			associate,
+			permissionFor(
+				ORDER_PERMISSIONS.create,
+				owner === associate.associateId ? "my" : "others",
+			),
+			"create",
+			owner,
+		);
+
+		return draft;
 	}
 
 	registerRoutes(parent: FastifyInstance) {

--- a/src/services/as-associate-quote-request.ts
+++ b/src/services/as-associate-quote-request.ts
@@ -1,17 +1,74 @@
-import type { FastifyInstance } from "fastify";
-import type { MyQuoteRequestRepository } from "#src/repositories/my-quote-request.ts";
-import AbstractService from "./abstract.ts";
+import type { Cart } from "@commercetools/platform-sdk";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import {
+	permissionFor,
+	QUOTE_REQUEST_PERMISSIONS,
+	requirePermission,
+} from "#src/associate-permissions.ts";
+import type { AsAssociateQuoteRequestRepository } from "#src/repositories/as-associate.ts";
+import { getRepositoryContext } from "#src/repositories/helpers.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateQuoteRequestService extends AbstractService {
-	public repository: MyQuoteRequestRepository;
+export class AsAssociateQuoteRequestService extends AbstractAssociateService {
+	public repository: AsAssociateQuoteRequestRepository;
 
-	constructor(parent: FastifyInstance, repository: MyQuoteRequestRepository) {
+	protected rules: AssociateResourceRules = {
+		view: QUOTE_REQUEST_PERMISSIONS.view,
+		update: QUOTE_REQUEST_PERMISSIONS.update,
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		ownerWhere: (associateId) => `customer(id="${associateId}")`,
+		ownerOf: (quoteRequest) => quoteRequest.customer?.id,
+		businessUnitOf: (quoteRequest) => quoteRequest.businessUnit?.key,
+	};
+
+	constructor(
+		parent: FastifyInstance,
+		repository: AsAssociateQuoteRequestRepository,
+	) {
 		super(parent);
 		this.repository = repository;
 	}
 
 	getBasePath() {
 		return "quote-requests";
+	}
+
+	/**
+	 * A quote request is created from a cart, so the cart's owner decides
+	 * whether this is `My` or `Others`.
+	 */
+	protected override async authorizeCreate(
+		request: FastifyRequest<{ Params: Record<string, string> }>,
+		draft: unknown,
+	): Promise<unknown> {
+		const context = getRepositoryContext(request);
+		const associate = await this.associateContext(request);
+
+		const source = draft as { cartId?: string; cart?: { id?: string } };
+		const cartId = source.cartId ?? source.cart?.id;
+		const cart = cartId
+			? ((await this.repository.storage.get(
+					context.projectKey,
+					"cart",
+					cartId,
+				)) as Cart | null)
+			: null;
+
+		const owner = cart?.customerId;
+		requirePermission(
+			context,
+			associate,
+			permissionFor(
+				QUOTE_REQUEST_PERMISSIONS.create,
+				owner === associate.associateId ? "my" : "others",
+			),
+			"create",
+			owner,
+		);
+
+		return draft;
 	}
 
 	registerRoutes(parent: FastifyInstance) {

--- a/src/services/as-associate-quote.test.ts
+++ b/src/services/as-associate-quote.test.ts
@@ -1,23 +1,20 @@
 import type { Quote } from "@commercetools/platform-sdk";
 import { afterEach, describe, expect, test } from "vitest";
-import { typeDraftFactory } from "#src/testing/index.ts";
+import { createAssociateScope, typeDraftFactory } from "#src/testing/index.ts";
 import { CommercetoolsMock, getBaseResourceProperties } from "../index.ts";
 
 const ctMock = new CommercetoolsMock({ defaultProjectKey: "dummy" });
-const projectKey = "dummy";
-const associateId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
-const businessUnitKey = "test-business-unit";
-const basePath = `/${projectKey}/as-associate/${associateId}/in-business-unit/key=${businessUnitKey}/quotes`;
 
-const createQuote = async () => {
+const createQuote = async (scope: {
+	associateId: string;
+	businessUnitKey: string;
+}) => {
 	const quote: Quote = {
 		...getBaseResourceProperties(),
 		key: "quote-1",
 		quoteState: "Pending",
-		customer: {
-			typeId: "customer",
-			id: "8d4d2b1a-6d90-4f0f-9e34-3c1a01e6b3f1",
-		},
+		customer: { typeId: "customer", id: scope.associateId },
+		businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
 		quoteRequest: {
 			typeId: "quote-request",
 			id: "0f0f0a3b-6a2f-4a4c-9a05-6a6b0a5f7d3e",
@@ -50,11 +47,14 @@ describe("AsAssociate quotes", () => {
 	});
 
 	test("query quotes", async () => {
-		const quote = await createQuote();
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyQuotes"],
+		});
+		const quote = await createQuote(scope);
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: basePath,
+			url: `${scope.basePath}/quotes`,
 		});
 
 		expect(response.statusCode).toBe(200);
@@ -63,11 +63,14 @@ describe("AsAssociate quotes", () => {
 	});
 
 	test("get quote by id", async () => {
-		const quote = await createQuote();
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyQuotes"],
+		});
+		const quote = await createQuote(scope);
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `${basePath}/${quote.id}`,
+			url: `${scope.basePath}/quotes/${quote.id}`,
 		});
 
 		expect(response.statusCode).toBe(200);
@@ -75,11 +78,14 @@ describe("AsAssociate quotes", () => {
 	});
 
 	test("get quote by key", async () => {
-		const quote = await createQuote();
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyQuotes"],
+		});
+		const quote = await createQuote(scope);
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `${basePath}/key=${quote.key}`,
+			url: `${scope.basePath}/quotes/key=${quote.key}`,
 		});
 
 		expect(response.statusCode).toBe(200);
@@ -87,16 +93,22 @@ describe("AsAssociate quotes", () => {
 	});
 
 	test("get unknown quote", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyQuotes"],
+		});
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `${basePath}/2c4bb2c1-0f4f-4c1e-9d2f-9a1d3e4b5c6a`,
+			url: `${scope.basePath}/quotes/2c4bb2c1-0f4f-4c1e-9d2f-9a1d3e4b5c6a`,
 		});
 
 		expect(response.statusCode).toBe(404);
 	});
 
 	test("update quote by id", async () => {
-		const quote = await createQuote();
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyQuotes"],
+		});
+		const quote = await createQuote(scope);
 		const type = await typeDraftFactory(ctMock).create({
 			key: "quote-type",
 			name: { en: "quote-type" },
@@ -105,7 +117,7 @@ describe("AsAssociate quotes", () => {
 
 		const response = await ctMock.app.inject({
 			method: "POST",
-			url: `${basePath}/${quote.id}`,
+			url: `${scope.basePath}/quotes/${quote.id}`,
 			payload: {
 				version: quote.version,
 				actions: [
@@ -121,5 +133,48 @@ describe("AsAssociate quotes", () => {
 		expect(response.statusCode).toBe(200);
 		expect(response.json().version).toBe(quote.version + 1);
 		expect(response.json().custom.fields).toEqual({ foo: "bar" });
+	});
+	test("accepting a quote needs AcceptMyQuotes", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyQuotes"],
+		});
+		const quote = await createQuote(scope);
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/quotes/${quote.id}`,
+			payload: {
+				version: quote.version,
+				actions: [{ action: "changeQuoteState", quoteState: "Accepted" }],
+			},
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual(["AcceptMyQuotes"]);
+	});
+
+	test("declining a colleague's quote needs DeclineOthersQuotes", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewOthersQuotes", "DeclineMyQuotes"],
+		});
+		const colleague = await createAssociateScope(ctMock);
+		const quote = await createQuote({
+			associateId: colleague.associateId,
+			businessUnitKey: scope.businessUnitKey,
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/quotes/${quote.id}`,
+			payload: {
+				version: quote.version,
+				actions: [{ action: "changeQuoteState", quoteState: "Declined" }],
+			},
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual([
+			"DeclineOthersQuotes",
+		]);
 	});
 });

--- a/src/services/as-associate-quote.ts
+++ b/src/services/as-associate-quote.ts
@@ -1,9 +1,24 @@
 import type { FastifyInstance } from "fastify";
+import {
+	QUOTE_PERMISSIONS,
+	quoteActionPermission,
+} from "#src/associate-permissions.ts";
 import type { AsAssociateQuoteRepository } from "#src/repositories/as-associate.ts";
-import AbstractService from "./abstract.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateQuoteService extends AbstractService {
+export class AsAssociateQuoteService extends AbstractAssociateService {
 	public repository: AsAssociateQuoteRepository;
+
+	protected rules: AssociateResourceRules = {
+		view: QUOTE_PERMISSIONS.view,
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		ownerWhere: (associateId) => `customer(id="${associateId}")`,
+		ownerOf: (quote) => quote.customer?.id,
+		businessUnitOf: (quote) => quote.businessUnit?.key,
+		actionPermission: quoteActionPermission,
+	};
 
 	constructor(parent: FastifyInstance, repository: AsAssociateQuoteRepository) {
 		super(parent);

--- a/src/services/as-associate-shopping-list.test.ts
+++ b/src/services/as-associate-shopping-list.test.ts
@@ -1,48 +1,112 @@
-import { describe, expect, test } from "vitest";
-import { shoppingListDraftFactory } from "#src/testing/index.ts";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	createAssociateScope,
+	customerDraftFactory,
+	shoppingListDraftFactory,
+} from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
-const projectKey = "dummy";
-const customerId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
-const businessUnitKey = "test-business-unit";
 
 describe("AsAssociateShoppingList", () => {
 	const factory = shoppingListDraftFactory(ctMock);
 
+	let colleagues = 0;
+	const colleagueId = async () => {
+		colleagues += 1;
+		const customer = await customerDraftFactory(ctMock).create({
+			email: `list-colleague-${colleagues}@example.com`,
+		});
+		return customer.id;
+	};
+
+	afterEach(async () => {
+		await ctMock.clear();
+	});
+
 	test("Create shopping list", async () => {
-		const shoppingList = await factory.create({
-			name: { en: "My list" },
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["CreateMyShoppingLists"],
 		});
 
-		expect(shoppingList.id).toBeDefined();
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/shopping-lists`,
+			payload: { name: { en: "My list" } },
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().customer).toEqual({
+			typeId: "customer",
+			id: scope.associateId,
+		});
 	});
 
-	test("Get shopping list", async () => {
-		const shoppingList = await factory.create({
-			name: { en: "Groceries" },
+	test("Get own shopping list", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["CreateMyShoppingLists", "ViewMyShoppingLists"],
+		});
+
+		const created = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/shopping-lists`,
+			payload: { name: { en: "Groceries" } },
 		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/shopping-lists/${shoppingList.id}`,
+			url: `${scope.basePath}/shopping-lists/${created.json().id}`,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual(shoppingList);
+		expect(response.json().id).toBe(created.json().id);
 	});
 
-	test("Query shopping lists", async () => {
-		await factory.create({
+	test("Get a colleague's shopping list needs ViewOthersShoppingLists", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyShoppingLists"],
+		});
+
+		const list = await factory.create({
 			name: { en: "Errands" },
+			customer: { typeId: "customer", id: await colleagueId() },
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
 		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/shopping-lists`,
+			url: `${scope.basePath}/shopping-lists/${list.id}`,
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].permissions).toEqual([
+			"ViewOthersShoppingLists",
+		]);
+	});
+
+	test("Query shopping lists is narrowed to the caller", async () => {
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyShoppingLists"],
+		});
+
+		const own = await factory.create({
+			name: { en: "Mine" },
+			customer: { typeId: "customer", id: scope.associateId },
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
+		});
+		await factory.create({
+			name: { en: "Theirs" },
+			customer: { typeId: "customer", id: await colleagueId() },
+			businessUnit: { typeId: "business-unit", key: scope.businessUnitKey },
+		});
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${scope.basePath}/shopping-lists`,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json().count).toBeGreaterThan(0);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].id).toBe(own.id);
 	});
 });

--- a/src/services/as-associate-shopping-list.ts
+++ b/src/services/as-associate-shopping-list.ts
@@ -1,36 +1,42 @@
 import type { FastifyInstance } from "fastify";
-import type { ShoppingListRepository } from "#src/repositories/shopping-list/index.ts";
-import AbstractService from "./abstract.ts";
+import { SHOPPING_LIST_PERMISSIONS } from "#src/associate-permissions.ts";
+import type { AsAssociateShoppingListRepository } from "#src/repositories/as-associate.ts";
+import AbstractAssociateService, {
+	type AssociateResourceRules,
+} from "./abstract-associate.ts";
 
-export class AsAssociateShoppingListService extends AbstractService {
-	public repository: ShoppingListRepository;
+export class AsAssociateShoppingListService extends AbstractAssociateService {
+	public repository: AsAssociateShoppingListRepository;
 
-	constructor(parent: FastifyInstance, repository: ShoppingListRepository) {
+	protected rules: AssociateResourceRules = {
+		view: SHOPPING_LIST_PERMISSIONS.view,
+		create: SHOPPING_LIST_PERMISSIONS.create,
+		update: SHOPPING_LIST_PERMISSIONS.update,
+		delete: SHOPPING_LIST_PERMISSIONS.delete,
+		businessUnitWhere: (key) => `businessUnit(key="${key}")`,
+		ownerWhere: (associateId) => `customer(id="${associateId}")`,
+		ownerOf: (list) => list.customer?.id,
+		businessUnitOf: (list) => list.businessUnit?.key,
+		ownerOfDraft: (draft) => draft.customer?.id,
+		stampDraft: (draft, scope) => ({
+			...draft,
+			customer: draft.customer ?? { typeId: "customer", id: scope.associateId },
+			businessUnit: draft.businessUnit ?? {
+				typeId: "business-unit",
+				key: scope.businessUnitKey,
+			},
+		}),
+	};
+
+	constructor(
+		parent: FastifyInstance,
+		repository: AsAssociateShoppingListRepository,
+	) {
 		super(parent);
 		this.repository = repository;
 	}
 
 	getBasePath() {
 		return "shopping-lists";
-	}
-
-	registerRoutes(parent: FastifyInstance) {
-		const basePath = this.getBasePath();
-		parent.register(
-			(instance, opts, done) => {
-				this.extraRoutes(instance);
-
-				instance.get("/", this.get.bind(this));
-				instance.get("/:id", this.getWithId.bind(this));
-
-				instance.delete("/:id", this.deleteWithId.bind(this));
-
-				instance.post("/", this.post.bind(this));
-				instance.post("/:id", this.postWithId.bind(this));
-
-				done();
-			},
-			{ prefix: `/${basePath}` },
-		);
 	}
 }

--- a/src/services/as-associate.test.ts
+++ b/src/services/as-associate.test.ts
@@ -1,40 +1,55 @@
-import { describe, expect, test } from "vitest";
-import { cartDraftFactory } from "#src/testing/index.ts";
+import { afterEach, describe, expect, test } from "vitest";
+import { cartDraftFactory, createAssociateScope } from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
-const projectKey = "dummy";
-const customerId = "5fac8fca-2484-4b14-a1d1-cfdce2f8d3c4";
-const businessUnitKey = "test-business-unit";
 
 describe("AsAssociate", () => {
 	const cartFactory = cartDraftFactory(ctMock);
 
+	afterEach(async () => {
+		await ctMock.clear();
+	});
+
 	test("Access as-associate service routes", async () => {
-		// Test that the as-associate service sets up routes correctly by testing cart endpoint
-		const response = await ctMock.app.inject({
-			method: "GET",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/carts`,
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["ViewMyCarts"],
 		});
 
-		// Should return 200 with empty results or 404 if not configured
-		expect([200, 404]).toContain(response.statusCode);
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `${scope.basePath}/carts`,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().results).toEqual([]);
 	});
 
 	test("Create cart via as-associate", async () => {
-		const draft = cartFactory.build({
-			currency: "EUR",
+		const scope = await createAssociateScope(ctMock, {
+			permissions: ["CreateMyCarts"],
 		});
 
 		const response = await ctMock.app.inject({
 			method: "POST",
-			url: `/${projectKey}/as-associate/${customerId}/in-business-unit/key=${businessUnitKey}/carts`,
-			payload: draft,
+			url: `${scope.basePath}/carts`,
+			payload: cartFactory.build({ currency: "EUR" }),
 		});
 
 		expect(response.statusCode).toBe(201);
+		expect(response.json().id).toBeDefined();
+	});
 
-		const cart = response.json();
-		expect(cart.id).toBeDefined();
+	test("An associate without any role is refused", async () => {
+		const scope = await createAssociateScope(ctMock, { permissions: [] });
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: `${scope.basePath}/carts`,
+			payload: cartFactory.build({ currency: "EUR" }),
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("AssociateMissingPermission");
 	});
 });

--- a/src/services/custom-object.test.ts
+++ b/src/services/custom-object.test.ts
@@ -167,7 +167,7 @@ describe("CustomObject retrieve", () => {
 	});
 
 	test("can use the add function with the custom object name", async () => {
-		ctMock.project("dummy").unsafeAdd("key-value-document", {
+		await ctMock.project("dummy").unsafeAdd("key-value-document", {
 			...getBaseResourceProperties(),
 			container: "my-container",
 			key: "my-key",
@@ -190,7 +190,7 @@ describe("CustomObject retrieve", () => {
 			lastModifiedAt: expect.anything(),
 			lastModifiedBy: expect.anything(),
 			value: "my-value",
-			version: 1,
+			version: 2,
 		});
 	});
 

--- a/src/services/my-business-unit.test.ts
+++ b/src/services/my-business-unit.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, describe, expect, test } from "vitest";
-import { businessUnitDraftFactory } from "#src/testing/business-unit.ts";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	businessUnitDraftFactory,
+	createAssociateScope,
+	loginCustomer,
+} from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
@@ -7,163 +11,97 @@ const ctMock = new CommercetoolsMock();
 describe("MyBusinessUnit", () => {
 	const businessUnitFactory = businessUnitDraftFactory(ctMock);
 
+	let scope: Awaited<ReturnType<typeof createAssociateScope>>;
+	let headers: { authorization: string };
+
+	beforeEach(async () => {
+		scope = await createAssociateScope(ctMock);
+		const customer = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/customers/${scope.associateId}`,
+		});
+		headers = (
+			await loginCustomer(ctMock, {
+				email: customer.json().email,
+				password: "my-secret-pw",
+			})
+		).headers;
+	});
+
 	afterEach(async () => {
 		await ctMock.clear();
 	});
 
 	test("Get my business units", async () => {
+		// A unit the caller is not an associate of
 		await businessUnitFactory.create({
-			key: "my-business-unit",
+			key: "someone-elses-unit",
 			unitType: "Company",
-			name: "My Business Unit",
+			name: "Someone else",
 			contactEmail: "contact@example.com",
 		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
 			url: "/dummy/me/business-units",
+			headers,
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(response.json().count).toBeGreaterThanOrEqual(0);
-		expect(response.json().results).toBeDefined();
-	});
-
-	test("Get my business unit by ID", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "my-business-unit",
-			unitType: "Company",
-			name: "My Business Unit",
-			contactEmail: "contact@example.com",
-		});
-
-		const response = await ctMock.app.inject({
-			method: "GET",
-			url: `/dummy/me/business-units/${businessUnit.id}`,
-		});
-
-		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual(businessUnit);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].key).toBe(scope.businessUnitKey);
 	});
 
 	test("Get my business unit by key", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "my-business-unit",
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/me/business-units/key=${scope.businessUnitKey}`,
+			headers,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().key).toBe(scope.businessUnitKey);
+	});
+
+	test("Get a business unit the caller is not an associate of", async () => {
+		const other = await businessUnitFactory.create({
+			key: "someone-elses-unit",
 			unitType: "Company",
-			name: "My Business Unit",
+			name: "Someone else",
 			contactEmail: "contact@example.com",
 		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
-			url: `/dummy/me/business-units/key=${businessUnit.key}`,
+			url: `/dummy/me/business-units/${other.id}`,
+			headers,
 		});
 
-		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual(businessUnit);
-	});
-
-	test("Delete my business unit", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "my-business-unit",
-			unitType: "Company",
-			name: "My Business Unit",
-			contactEmail: "contact@example.com",
-		});
-
-		// Now delete the business unit
-		const deleteResponse = await ctMock.app.inject({
-			method: "DELETE",
-			url: `/dummy/me/business-units/${businessUnit.id}`,
-		});
-
-		expect(deleteResponse.statusCode).toBe(200);
-		expect(deleteResponse.json()).toEqual(businessUnit);
-
-		// Verify that the business unit is deleted
-		const newResponse = await ctMock.app.inject({
-			method: "GET",
-			url: `/dummy/me/business-units/${businessUnit.id}`,
-		});
-		expect(newResponse.statusCode).toBe(404);
-	});
-
-	test("Delete my business unit by key", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "my-business-unit",
-			unitType: "Company",
-			name: "My Business Unit",
-			contactEmail: "contact@example.com",
-		});
-
-		// Now delete the business unit
-		const deleteResponse = await ctMock.app.inject({
-			method: "DELETE",
-			url: `/dummy/me/business-units/key=${businessUnit.key}`,
-		});
-
-		expect(deleteResponse.statusCode).toBe(200);
-		expect(deleteResponse.json()).toEqual(businessUnit);
-
-		// Verify that the business unit is deleted
-		const newResponse = await ctMock.app.inject({
-			method: "GET",
-			url: `/dummy/me/business-units/key=${businessUnit.key}`,
-		});
-		expect(newResponse.statusCode).toBe(404);
+		expect(response.statusCode).toBe(404);
 	});
 
 	test("Update my business unit", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "my-business-unit",
-			unitType: "Company",
-			name: "My Business Unit",
-			contactEmail: "contact@example.com",
-		});
-
-		const updateResponse = await ctMock.app.inject({
+		const response = await ctMock.app.inject({
 			method: "POST",
-			url: `/dummy/me/business-units/${businessUnit.id}`,
+			url: `/dummy/me/business-units/key=${scope.businessUnitKey}`,
 			payload: {
-				id: businessUnit.id,
-				version: businessUnit.version,
-				actions: [
-					{
-						action: "changeName",
-						name: "Updated Business Unit Name",
-					},
-				],
+				version: 1,
+				actions: [{ action: "changeName", name: "Updated Name" }],
 			},
+			headers,
 		});
 
-		expect(updateResponse.statusCode).toBe(200);
-		expect(updateResponse.json().name).toBe("Updated Business Unit Name");
+		expect(response.statusCode).toBe(200);
+		expect(response.json().name).toBe("Updated Name");
 	});
 
-	test("Update my business unit by key", async () => {
-		const businessUnit = await businessUnitFactory.create({
-			key: "my-business-unit",
-			unitType: "Company",
-			name: "My Business Unit",
-			contactEmail: "contact@example.com",
+	test("Without a customer token", async () => {
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/business-units",
 		});
 
-		const updateResponse = await ctMock.app.inject({
-			method: "POST",
-			url: `/dummy/me/business-units/key=${businessUnit.key}`,
-			payload: {
-				id: businessUnit.id,
-				version: businessUnit.version,
-				actions: [
-					{
-						action: "changeName",
-						name: "Updated Business Unit Name",
-					},
-				],
-			},
-		});
-
-		expect(updateResponse.statusCode).toBe(200);
-		expect(updateResponse.json().name).toBe("Updated Business Unit Name");
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("insufficient_scope");
 	});
 });

--- a/src/services/my-business-unit.ts
+++ b/src/services/my-business-unit.ts
@@ -1,13 +1,36 @@
 import type { FastifyInstance } from "fastify";
 import type { BusinessUnitRepository } from "#src/repositories/business-unit.ts";
-import AbstractService from "./abstract.ts";
+import AbstractMyService, { type MyResourceRules } from "./abstract-my.ts";
 
-export class MyBusinessUnitService extends AbstractService {
+export class MyBusinessUnitService extends AbstractMyService {
 	public repository: BusinessUnitRepository;
+
+	// A customer's business units are the ones they are an associate of
+	protected myRules: MyResourceRules = {
+		customerWhere: (customerId) => `associates(customer(id="${customerId}"))`,
+		customerOf: () => undefined,
+	};
 
 	constructor(parent: FastifyInstance, repository: BusinessUnitRepository) {
 		super(parent);
 		this.repository = repository;
+	}
+
+	protected override owns(
+		identity: { type: "customer" | "anonymous"; id: string },
+		resource: unknown,
+	): boolean {
+		if (identity.type !== "customer") {
+			return false;
+		}
+		const businessUnit = resource as {
+			associates?: { customer: { id: string } }[];
+			inheritedAssociates?: { customer: { id: string } }[];
+		};
+		return [
+			...(businessUnit.associates ?? []),
+			...(businessUnit.inheritedAssociates ?? []),
+		].some((associate) => associate.customer.id === identity.id);
 	}
 
 	getBasePath() {

--- a/src/services/my-cart.test.ts
+++ b/src/services/my-cart.test.ts
@@ -1,6 +1,11 @@
 import type { Cart } from "@commercetools/platform-sdk";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { cartDraftFactory, typeDraftFactory } from "#src/testing/index.ts";
+import {
+	cartDraftFactory,
+	customerDraftFactory,
+	loginCustomer,
+	typeDraftFactory,
+} from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
@@ -9,7 +14,22 @@ describe("MyCart", () => {
 	const cartDraft = cartDraftFactory(ctMock);
 	const typeDraft = typeDraftFactory(ctMock);
 
+	let customerId: string;
+	let headers: { authorization: string };
+
 	beforeEach(async () => {
+		const customer = await customerDraftFactory(ctMock).create({
+			email: "my-cart@example.com",
+			password: "secret",
+		});
+		customerId = customer.id;
+		headers = (
+			await loginCustomer(ctMock, {
+				email: "my-cart@example.com",
+				password: "secret",
+			})
+		).headers;
+
 		await typeDraft.create({
 			key: "custom-payment",
 			name: {
@@ -32,6 +52,7 @@ describe("MyCart", () => {
 			method: "POST",
 			url: "/dummy/me/carts",
 			payload: draft,
+			headers,
 		});
 
 		expect(response.statusCode).toBe(201);
@@ -43,6 +64,7 @@ describe("MyCart", () => {
 			lastModifiedBy: expect.anything(),
 			version: 1,
 			cartState: "Active",
+			customerId,
 			discountCodes: [],
 			directDiscounts: [],
 			inventoryMode: "None",
@@ -67,37 +89,100 @@ describe("MyCart", () => {
 	});
 
 	test("Get my cart by ID", async () => {
-		const cart = await cartDraft.create({
-			currency: "EUR",
-		});
+		const cart = await cartDraft.create({ currency: "EUR", customerId });
 
 		const response = await ctMock.app.inject({
 			method: "GET",
 			url: `/dummy/me/carts/${cart.id}`,
+			headers,
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual(cart);
 	});
 
-	test("Get my active cart", async () => {
+	test("Get a cart of another customer by ID", async () => {
+		const other = await customerDraftFactory(ctMock).create({
+			email: "someone-else@example.com",
+		});
 		const cart = await cartDraft.create({
 			currency: "EUR",
+			customerId: other.id,
 		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
+			url: `/dummy/me/carts/${cart.id}`,
+			headers,
+		});
+
+		// Not visible, and indistinguishable from a cart that does not exist
+		expect(response.statusCode).toBe(404);
+	});
+
+	test("Query my carts", async () => {
+		const other = await customerDraftFactory(ctMock).create({
+			email: "someone-else@example.com",
+		});
+		const mine = await cartDraft.create({ currency: "EUR", customerId });
+		await cartDraft.create({ currency: "EUR", customerId: other.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/carts",
+			headers,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].id).toBe(mine.id);
+	});
+
+	test("Without a customer token", async () => {
+		await cartDraft.create({ currency: "EUR", customerId });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/carts",
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("insufficient_scope");
+	});
+
+	test("Get my active cart", async () => {
+		const cart = await cartDraft.create({ currency: "EUR", customerId });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
 			url: "/dummy/me/active-cart",
+			headers,
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual(cart);
+	});
+
+	test("Get my active cart when only another customer has one", async () => {
+		const other = await customerDraftFactory(ctMock).create({
+			email: "someone-else@example.com",
+		});
+		await cartDraft.create({ currency: "EUR", customerId: other.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/active-cart",
+			headers,
+		});
+
+		expect(response.statusCode).toBe(404);
 	});
 
 	test("Get my active cart which doesnt exists", async () => {
 		const response = await ctMock.app.inject({
 			method: "GET",
 			url: "/dummy/me/active-cart",
+			headers,
 		});
 
 		expect(response.statusCode).toBe(404);

--- a/src/services/my-cart.ts
+++ b/src/services/my-cart.ts
@@ -1,11 +1,23 @@
 import type { ResourceNotFoundError } from "@commercetools/platform-sdk";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { CommercetoolsError } from "#src/exceptions.ts";
+import { getRepositoryContext } from "#src/repositories/helpers.ts";
 import type { CartRepository } from "../repositories/cart/index.ts";
-import AbstractService from "./abstract.ts";
+import AbstractMyService, { type MyResourceRules } from "./abstract-my.ts";
 
-export class MyCartService extends AbstractService {
+export class MyCartService extends AbstractMyService {
 	public repository: CartRepository;
+
+	protected myRules: MyResourceRules = {
+		customerWhere: (customerId) => `customerId="${customerId}"`,
+		anonymousWhere: (anonymousId) => `anonymousId="${anonymousId}"`,
+		customerOf: (cart) => cart.customerId,
+		anonymousOf: (cart) => cart.anonymousId,
+		stampDraft: (draft, identity) =>
+			identity.type === "customer"
+				? { ...draft, customerId: identity.id }
+				: { ...draft, anonymousId: identity.id },
+	};
 
 	constructor(parent: FastifyInstance, repository: CartRepository) {
 		super(parent);
@@ -42,8 +54,13 @@ export class MyCartService extends AbstractService {
 		request: FastifyRequest<{ Params: Record<string, string> }>,
 		reply: FastifyReply,
 	) {
-		const params = request.params;
-		const resource = await this.repository.getActiveCart(params.projectKey);
+		const context = getRepositoryContext(request);
+		const identity = this.identityOf(context);
+
+		const resource = await this.repository.getActiveCart(context.projectKey, {
+			customerId: identity.type === "customer" ? identity.id : undefined,
+			anonymousId: identity.type === "anonymous" ? identity.id : undefined,
+		});
 		if (!resource) {
 			throw new CommercetoolsError<ResourceNotFoundError>(
 				{

--- a/src/services/my-customer.test.ts
+++ b/src/services/my-customer.test.ts
@@ -4,7 +4,7 @@ import type {
 	CustomerToken,
 } from "@commercetools/platform-sdk";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { customerDraftFactory } from "#src/testing/index.ts";
+import { customerDraftFactory, customerSession } from "#src/testing/index.ts";
 import { CommercetoolsMock, getBaseResourceProperties } from "../index.ts";
 import { hashPassword } from "../lib/password.ts";
 
@@ -63,14 +63,51 @@ describe("Me", () => {
 		const response = await ctMock.app.inject({
 			method: "GET",
 			url: "/dummy/me",
+			headers: customerSession(ctMock, customer.id).headers,
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual(customer);
 	});
+
+	test("Get me without a customer token", async () => {
+		await customerFactory.create({
+			email: "test@example.org",
+			password: "p4ssw0rd",
+		});
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me",
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("insufficient_scope");
+	});
+
+	test("Get me returns the customer the token was issued for", async () => {
+		const mine = await customerFactory.create({
+			email: "mine@example.org",
+			password: "p4ssw0rd",
+		});
+		await customerFactory.create({
+			email: "someone-else@example.org",
+			password: "p4ssw0rd",
+		});
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me",
+			headers: customerSession(ctMock, mine.id).headers,
+		});
+
+		expect(response.json().id).toBe(mine.id);
+	});
 });
 
 describe("/me", () => {
+	const headers = customerSession(ctMock, "123").headers;
+
 	afterEach(() => {
 		ctMock.clear();
 	});
@@ -97,6 +134,7 @@ describe("/me", () => {
 		const response = await ctMock.app.inject({
 			method: "GET",
 			url: "/dummy/me",
+			headers,
 		});
 
 		expect(response.statusCode).toBe(200);
@@ -129,6 +167,7 @@ describe("/me", () => {
 		const response = await ctMock.app.inject({
 			method: "DELETE",
 			url: "/dummy/me",
+			headers,
 		});
 
 		expect(response.statusCode).toBe(200);
@@ -159,6 +198,7 @@ describe("/me", () => {
 		const newResponse = await ctMock.app.inject({
 			method: "GET",
 			url: "/dummy/me",
+			headers,
 		});
 		expect(newResponse.statusCode).toBe(404);
 	});
@@ -345,6 +385,7 @@ describe("/me", () => {
 				version: 2,
 				actions: [{ action: "setCustomField", name: "foobar", value: true }],
 			},
+			headers,
 		});
 		expect(response.statusCode).toBe(200);
 		expect(response.json().version).toBe(3);
@@ -355,6 +396,7 @@ describe("/me", () => {
 		const response = await ctMock.app.inject({
 			method: "DELETE",
 			url: "/dummy/me",
+			headers,
 		});
 		expect(response.statusCode).toBe(200);
 		expect(response.json().id).toBeDefined();

--- a/src/services/my-order.test.ts
+++ b/src/services/my-order.test.ts
@@ -1,0 +1,147 @@
+import type { Order } from "@commercetools/platform-sdk";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	anonymousSession,
+	customerDraftFactory,
+	customerSession,
+} from "#src/testing/index.ts";
+import { CommercetoolsMock, getBaseResourceProperties } from "../index.ts";
+
+const ctMock = new CommercetoolsMock();
+
+const addOrder = async (owner: {
+	customerId?: string;
+	anonymousId?: string;
+}) => {
+	const order: Order = {
+		...getBaseResourceProperties(),
+		...owner,
+		customLineItems: [],
+		lineItems: [],
+		lastMessageSequenceNumber: 0,
+		orderState: "Open",
+		origin: "Customer",
+		refusedGifts: [],
+		shipping: [],
+		shippingMode: "Single",
+		syncInfo: [],
+		totalPrice: {
+			type: "centPrecision",
+			currencyCode: "EUR",
+			centAmount: 1000,
+			fractionDigits: 2,
+		},
+	};
+	await ctMock.project("dummy").unsafeAdd("order", order);
+	return order;
+};
+
+describe("MyOrder", () => {
+	const customerFactory = customerDraftFactory(ctMock);
+
+	afterEach(async () => {
+		await ctMock.clear();
+	});
+
+	test("Get my order by id", async () => {
+		const customer = await customerFactory.create({
+			email: "mine@example.org",
+		});
+		const order = await addOrder({ customerId: customer.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/me/orders/${order.id}`,
+			headers: customerSession(ctMock, customer.id).headers,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().id).toBe(order.id);
+	});
+
+	test("Get another customer's order by id", async () => {
+		const customer = await customerFactory.create({
+			email: "mine@example.org",
+		});
+		const other = await customerFactory.create({ email: "theirs@example.org" });
+		const order = await addOrder({ customerId: other.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/me/orders/${order.id}`,
+			headers: customerSession(ctMock, customer.id).headers,
+		});
+
+		// The order the caller may not see is indistinguishable from one that
+		// does not exist
+		expect(response.statusCode).toBe(404);
+	});
+
+	test("Get another customer's order in store", async () => {
+		const customer = await customerFactory.create({
+			email: "mine@example.org",
+		});
+		const other = await customerFactory.create({ email: "theirs@example.org" });
+		const order = await addOrder({ customerId: other.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: `/dummy/in-store/key=some-store/me/orders/${order.id}`,
+			headers: customerSession(ctMock, customer.id).headers,
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test("Query my orders", async () => {
+		const customer = await customerFactory.create({
+			email: "mine@example.org",
+		});
+		const other = await customerFactory.create({ email: "theirs@example.org" });
+		const mine = await addOrder({ customerId: customer.id });
+		await addOrder({ customerId: other.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/orders",
+			headers: customerSession(ctMock, customer.id).headers,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].id).toBe(mine.id);
+	});
+
+	test("Query orders without a token", async () => {
+		const customer = await customerFactory.create({
+			email: "mine@example.org",
+		});
+		await addOrder({ customerId: customer.id });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/orders",
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("insufficient_scope");
+	});
+
+	test("An anonymous session sees its own orders", async () => {
+		const session = await anonymousSession(ctMock, {
+			anonymousId: "anon-1",
+		});
+		const mine = await addOrder({ anonymousId: "anon-1" });
+		await addOrder({ anonymousId: "anon-2" });
+
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/orders",
+			headers: session.headers,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().results).toHaveLength(1);
+		expect(response.json().results[0].id).toBe(mine.id);
+	});
+});

--- a/src/services/my-order.ts
+++ b/src/services/my-order.ts
@@ -4,10 +4,17 @@ import { MyOrderFromQuoteDraftSchema } from "#src/schemas/generated/my-order-fro
 import { validateDraft } from "#src/validate.ts";
 import { getRepositoryContext } from "../repositories/helpers.ts";
 import type { MyOrderRepository } from "../repositories/my-order.ts";
-import AbstractService from "./abstract.ts";
+import AbstractMyService, { type MyResourceRules } from "./abstract-my.ts";
 
-export class MyOrderService extends AbstractService {
+export class MyOrderService extends AbstractMyService {
 	public repository: MyOrderRepository;
+
+	protected myRules: MyResourceRules = {
+		customerWhere: (customerId) => `customerId="${customerId}"`,
+		anonymousWhere: (anonymousId) => `anonymousId="${anonymousId}"`,
+		customerOf: (order) => order.customerId,
+		anonymousOf: (order) => order.anonymousId,
+	};
 
 	constructor(parent: FastifyInstance, repository: MyOrderRepository) {
 		super(parent);
@@ -51,15 +58,15 @@ export class MyOrderService extends AbstractService {
 			validateDraft(request.body, MyOrderFromQuoteDraftSchema);
 		}
 
+		const context = getRepositoryContext(request);
+		this.identityOf(context);
+
 		const { id, version, quoteStateToAccepted } = request.body;
-		const resource = await this.repository.createFromQuote(
-			getRepositoryContext(request),
-			{
-				quote: { typeId: "quote", id },
-				version,
-				quoteStateToAccepted,
-			},
-		);
+		const resource = await this.repository.createFromQuote(context, {
+			quote: { typeId: "quote", id },
+			version,
+			quoteStateToAccepted,
+		});
 		return reply.status(this.createStatusCode).send(resource);
 	}
 }

--- a/src/services/my-payment.test.ts
+++ b/src/services/my-payment.test.ts
@@ -1,6 +1,10 @@
 import type { MyPaymentDraft } from "@commercetools/platform-sdk";
-import { beforeEach, describe, expect, test } from "vitest";
-import { typeDraftFactory } from "#src/testing/index.ts";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	customerDraftFactory,
+	loginCustomer,
+	typeDraftFactory,
+} from "#src/testing/index.ts";
 import { CommercetoolsMock } from "../index.ts";
 
 const ctMock = new CommercetoolsMock();
@@ -8,7 +12,22 @@ const ctMock = new CommercetoolsMock();
 describe("MyPayment", () => {
 	const typeFactory = typeDraftFactory(ctMock);
 
+	let customerId: string;
+	let headers: { authorization: string };
+
 	beforeEach(async () => {
+		const customer = await customerDraftFactory(ctMock).create({
+			email: "my-payment@example.com",
+			password: "secret",
+		});
+		customerId = customer.id;
+		headers = (
+			await loginCustomer(ctMock, {
+				email: "my-payment@example.com",
+				password: "secret",
+			})
+		).headers;
+
 		await typeFactory.create({
 			key: "custom-payment",
 			name: {
@@ -16,6 +35,10 @@ describe("MyPayment", () => {
 			},
 			resourceTypeIds: ["payment"],
 		});
+	});
+
+	afterEach(async () => {
+		await ctMock.clear();
 	});
 
 	test("Create payment", async () => {
@@ -32,6 +55,7 @@ describe("MyPayment", () => {
 			method: "POST",
 			url: "/dummy/me/payments",
 			payload: draft,
+			headers,
 		});
 
 		expect(response.statusCode).toBe(201);
@@ -42,6 +66,7 @@ describe("MyPayment", () => {
 			lastModifiedAt: expect.anything(),
 			lastModifiedBy: expect.anything(),
 			version: 1,
+			customer: { typeId: "customer", id: customerId },
 			amountPlanned: {
 				type: "centPrecision",
 				fractionDigits: 2,
@@ -72,14 +97,26 @@ describe("MyPayment", () => {
 			method: "POST",
 			url: "/dummy/me/payments",
 			payload: draft,
+			headers,
 		});
 
 		const response = await ctMock.app.inject({
 			method: "GET",
 			url: `/dummy/me/payments/${createResponse.json().id}`,
+			headers,
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual(createResponse.json());
+	});
+
+	test("Without a customer token", async () => {
+		const response = await ctMock.app.inject({
+			method: "GET",
+			url: "/dummy/me/payments",
+		});
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json().errors[0].code).toBe("insufficient_scope");
 	});
 });

--- a/src/services/my-payment.ts
+++ b/src/services/my-payment.ts
@@ -1,9 +1,26 @@
 import type { FastifyInstance } from "fastify";
 import type { PaymentRepository } from "../repositories/payment/index.ts";
-import AbstractService from "./abstract.ts";
+import AbstractMyService, { type MyResourceRules } from "./abstract-my.ts";
 
-export class MyPaymentService extends AbstractService {
+export class MyPaymentService extends AbstractMyService {
 	public repository: PaymentRepository;
+
+	protected myRules: MyResourceRules = {
+		customerWhere: (customerId) => `customer(id="${customerId}")`,
+		anonymousWhere: (anonymousId) => `anonymousId="${anonymousId}"`,
+		customerOf: (payment) => payment.customer?.id,
+		anonymousOf: (payment) => payment.anonymousId,
+		stampDraft: (draft, identity) =>
+			identity.type === "customer"
+				? {
+						...draft,
+						customer: draft.customer ?? {
+							typeId: "customer",
+							id: identity.id,
+						},
+					}
+				: { ...draft, anonymousId: draft.anonymousId ?? identity.id },
+	};
 
 	constructor(parent: FastifyInstance, repository: PaymentRepository) {
 		super(parent);

--- a/src/services/my-shopping-list.ts
+++ b/src/services/my-shopping-list.ts
@@ -1,9 +1,26 @@
 import type { FastifyInstance } from "fastify";
 import type { ShoppingListRepository } from "../repositories/shopping-list/index.ts";
-import AbstractService from "./abstract.ts";
+import AbstractMyService, { type MyResourceRules } from "./abstract-my.ts";
 
-export class MyShoppingListService extends AbstractService {
+export class MyShoppingListService extends AbstractMyService {
 	public repository: ShoppingListRepository;
+
+	protected myRules: MyResourceRules = {
+		customerWhere: (customerId) => `customer(id="${customerId}")`,
+		anonymousWhere: (anonymousId) => `anonymousId="${anonymousId}"`,
+		customerOf: (list) => list.customer?.id,
+		anonymousOf: (list) => list.anonymousId,
+		stampDraft: (draft, identity) =>
+			identity.type === "customer"
+				? {
+						...draft,
+						customer: draft.customer ?? {
+							typeId: "customer",
+							id: identity.id,
+						},
+					}
+				: { ...draft, anonymousId: draft.anonymousId ?? identity.id },
+	};
 
 	constructor(parent: FastifyInstance, repository: ShoppingListRepository) {
 		super(parent);

--- a/src/services/order-from-quote.test.ts
+++ b/src/services/order-from-quote.test.ts
@@ -1,5 +1,6 @@
 import type { LineItem, Quote } from "@commercetools/platform-sdk";
 import { afterEach, describe, expect, test } from "vitest";
+import { customerSession } from "#src/testing/index.ts";
 import { CommercetoolsMock, getBaseResourceProperties } from "../index.ts";
 
 const ctMock = new CommercetoolsMock({ defaultProjectKey: "dummy" });
@@ -213,6 +214,7 @@ describe("Order from Quote", () => {
 				version: quote.version,
 				quoteStateToAccepted: true,
 			},
+			headers: customerSession(ctMock, customerId).headers,
 		});
 
 		expect(response.statusCode).toBe(201);
@@ -248,6 +250,7 @@ describe("Order from Quote draft validation", () => {
 			method: "POST",
 			url: "/dummy/me/orders/quotes",
 			payload: { id: "2c4bb2c1-0f4f-4c1e-9d2f-9a1d3e4b5c6a" },
+			headers: customerSession(strictMock, customerId).headers,
 		});
 
 		expect(response.statusCode).toBe(400);

--- a/src/testing/associate-scope.ts
+++ b/src/testing/associate-scope.ts
@@ -1,0 +1,66 @@
+import type { Permission } from "@commercetools/platform-sdk";
+import type { CommercetoolsMock } from "#src/ctMock.ts";
+import { associateRoleDraftFactory } from "./associate-role.ts";
+import { businessUnitDraftFactory } from "./business-unit.ts";
+import { customerDraftFactory } from "./customer.ts";
+
+let sequence = 0;
+
+export type AssociateScope = {
+	associateId: string;
+	businessUnitKey: string;
+	associateRoleKey: string;
+
+	/** `/{projectKey}/as-associate/{associateId}/in-business-unit/key={key}` */
+	basePath: string;
+};
+
+/**
+ * Seeds a customer, an associate role carrying `permissions`, and a business
+ * unit that has the customer as an associate with that role.
+ *
+ * The associate-scoped endpoints fail closed, so a test that exercises them
+ * needs all three to exist. This builds the smallest set that works, and hands
+ * back the path prefix to call.
+ */
+export const createAssociateScope = async (
+	m: CommercetoolsMock,
+	{
+		permissions = [],
+		projectKey = "dummy",
+		key,
+	}: { permissions?: Permission[]; projectKey?: string; key?: string } = {},
+): Promise<AssociateScope> => {
+	// Each factory here is created fresh, so its own sequence restarts on every
+	// call; the keys have to be unique across calls or a second scope would
+	// collide with the first
+	sequence += 1;
+	const customer = await customerDraftFactory(m).create({
+		email: `associate-${sequence}@example.com`,
+	});
+	const role = await associateRoleDraftFactory(m).create({
+		key: key ? `${key}-role` : `associate-role-${sequence}`,
+		permissions,
+	});
+	const businessUnit = await businessUnitDraftFactory(m).create({
+		key: key ?? `business-unit-${sequence}`,
+		associates: [
+			{
+				customer: { typeId: "customer", id: customer.id },
+				associateRoleAssignments: [
+					{
+						associateRole: { typeId: "associate-role", key: role.key },
+						inheritance: "Enabled",
+					},
+				],
+			},
+		],
+	});
+
+	return {
+		associateId: customer.id,
+		businessUnitKey: businessUnit.key,
+		associateRoleKey: role.key,
+		basePath: `/${projectKey}/as-associate/${customer.id}/in-business-unit/key=${businessUnit.key}`,
+	};
+};

--- a/src/testing/customer-token.ts
+++ b/src/testing/customer-token.ts
@@ -1,0 +1,90 @@
+import type { CommercetoolsMock } from "#src/ctMock.ts";
+
+export type CustomerSession = {
+	token: string;
+	headers: { authorization: string };
+};
+
+/**
+ * Issues a token for a customer that already exists, without going through the
+ * password flow. Handy for tests that seed a customer directly.
+ */
+export const customerSession = (
+	m: CommercetoolsMock,
+	customerId: string,
+	{ projectKey = "dummy" }: { projectKey?: string } = {},
+): CustomerSession => {
+	const token = m.authStore().getCustomerToken(projectKey, customerId, "");
+	return {
+		token: token.access_token,
+		headers: { authorization: `Bearer ${token.access_token}` },
+	};
+};
+
+/**
+ * Signs a customer in and returns the token, plus the header to send it with.
+ *
+ * The `/me` endpoints answer for the customer a token was issued to, so a test
+ * that exercises them needs one. Works whether or not `enableAuthentication` is
+ * on: the mock resolves the identity from any token it issued.
+ */
+export const loginCustomer = async (
+	m: CommercetoolsMock,
+	{
+		email,
+		password,
+		projectKey = "dummy",
+	}: { email: string; password: string; projectKey?: string },
+): Promise<CustomerSession> => {
+	const response = await m.app.inject({
+		method: "POST",
+		url: `/oauth/${projectKey}/customers/token`,
+		headers: {
+			authorization: `Basic ${Buffer.from("client:secret").toString("base64")}`,
+			"content-type": "application/x-www-form-urlencoded",
+		},
+		payload: new URLSearchParams({
+			grant_type: "password",
+			username: email,
+			password,
+		}).toString(),
+	});
+
+	if (response.statusCode !== 200) {
+		throw new Error(`Could not sign in ${email}: ${response.body}`);
+	}
+
+	const token = response.json().access_token;
+	return { token, headers: { authorization: `Bearer ${token}` } };
+};
+
+/**
+ * Starts an anonymous session and returns its token.
+ */
+export const anonymousSession = async (
+	m: CommercetoolsMock,
+	{
+		anonymousId,
+		projectKey = "dummy",
+	}: { anonymousId?: string; projectKey?: string } = {},
+): Promise<CustomerSession> => {
+	const response = await m.app.inject({
+		method: "POST",
+		url: `/oauth/${projectKey}/anonymous/token`,
+		headers: {
+			authorization: `Basic ${Buffer.from("client:secret").toString("base64")}`,
+			"content-type": "application/x-www-form-urlencoded",
+		},
+		payload: new URLSearchParams({
+			grant_type: "client_credentials",
+			...(anonymousId ? { anonymous_id: anonymousId } : {}),
+		}).toString(),
+	});
+
+	if (response.statusCode !== 200) {
+		throw new Error(`Could not start an anonymous session: ${response.body}`);
+	}
+
+	const token = response.json().access_token;
+	return { token, headers: { authorization: `Bearer ${token}` } };
+};

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,6 +1,7 @@
 export { approvalFlowDraftFactory } from "./approval-flow.ts";
 export { approvalRuleDraftFactory } from "./approval-rule.ts";
 export { associateRoleDraftFactory } from "./associate-role.ts";
+export { createAssociateScope } from "./associate-scope.ts";
 export { attributeGroupDraftFactory } from "./attribute-group.ts";
 export { businessUnitDraftFactory } from "./business-unit.ts";
 export { cartDraftFactory } from "./cart.ts";
@@ -10,6 +11,11 @@ export { channelDraftFactory } from "./channel.ts";
 export { customObjectDraftFactory } from "./custom-object.ts";
 export { customerDraftFactory } from "./customer.ts";
 export { customerGroupDraftFactory } from "./customer-group.ts";
+export {
+	anonymousSession,
+	customerSession,
+	loginCustomer,
+} from "./customer-token.ts";
 export { discountCodeDraftFactory } from "./discount-code.ts";
 export { discountGroupDraftFactory } from "./discount-group.ts";
 export { extensionDraftFactory } from "./extension.ts";

--- a/tsdown.config.js
+++ b/tsdown.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig([
 	{
-		entry: ["src/index.ts", "src/storage/sqlite.ts"],
+		entry: ["src/index.ts", "src/storage/sqlite.ts", "src/testing/index.ts"],
 		clean: true,
 		splitting: false,
 		dts: true,


### PR DESCRIPTION
Fixes #98 and #258. **Breaking — major release.**

Per the decisions in those threads: `My` means the resource's customer is the caller, `Others` means a different customer in the same business unit, all 47 permissions are modelled, and both scopes fail closed.

## What changed

**`/me`** answers for the customer or anonymous session the bearer token was issued for. No token → `403 insufficient_scope`. Someone else's resource → `404`, not a leak. Resources created through `/me` are stamped with the caller so they can be read back.

That closes the case @korsvanloon described in #98: `MyOrderService` inherited `getWithId` from `AbstractService` and resolved straight out of the repository, so `/me/orders/{id}` and the in-store variant returned any order. Both are covered by tests now.

**`as-associate`** resolves the associate named in the path against the business unit named in the path, collects the permissions of their AssociateRoles, and enforces them:

- List with only the `My` permission is **narrowed** to the caller rather than refused — that is what commercetools does, and refusing would be surprising.
- Anything else missing → `403 AssociateMissingPermission`, carrying the `permissions` that would have sufficed and using commercetools' message shape.
- A resource of another business unit → `404`.
- Quotes have no blanket update permission, so they are policed per action: `changeQuoteState: Accepted` needs `AcceptMy/OthersQuotes`, `Declined` needs `Decline…`, `requestQuoteRenegotiation` needs `Renegotiate…`, `changeCustomer` needs `Reassign…`. Business units are the same shape: `UpdateAssociates` / `UpdateParentUnit` / `UpdateBusinessUnitDetails` per action.
- `/as-associate/{id}/business-units` is the one resource outside `in-business-unit/key=`, so it checks against the unit in the resource: the list is narrowed to units the caller is an associate of.

The full table lives in `src/associate-permissions.ts`, one place to check the mapping against the docs.

## The one design call worth flagging

Identity resolution is now **independent of `enableAuthentication`**. The oauth middleware always runs and reads the identity out of a token the mock issued; only *enforcement* stays behind `validateCredentials`. Without this, scoping would be unreachable with the default options (the middleware was only installed when authentication was on), so `/me` would 403 with no way to authenticate.

## Adjacent fixes, needed for the scopes to work at all

- `POST /oauth/{projectKey}/anonymous/token` honours a supplied `anonymous_id` instead of always generating one.
- `PaymentDraft.customer` / `anonymousId` are stored — they were dropped, so a `/me` payment could not belong to anyone.
- An order and a quote request created from a cart carry the cart's `businessUnit`, otherwise they fell outside the scope that created them.
- `GET /me/active-cart` answers for the caller instead of returning the first active cart in the project.
- `MyCustomerRepository.getMe`/`deleteMe` use the token's customer instead of "grab the first customer you can find for now", which is what the code said it was doing.

## Migration

Tests calling these endpoints now have to say who is calling, so the testing helpers are exported as a new `@labdigital/commercetools-mock/testing` entrypoint:

```typescript
import { createAssociateScope, customerSession } from '@labdigital/commercetools-mock/testing'

const { headers } = customerSession(ctMock, customer.id)
await ctMock.app.inject({ method: 'GET', url: '/my-project/me/orders', headers })

const scope = await createAssociateScope(ctMock, { permissions: ['ViewMyCarts'] })
await ctMock.app.inject({ method: 'GET', url: `${scope.basePath}/carts` })
```

`loginCustomer` goes through the password grant when you want to exercise sign-in; `anonymousSession` starts an anonymous one.

The authentication docs page has a new "Scoped endpoints" section, and the stale bullet saying `/me` ignores the token's `customer_id` is gone.

## Coverage

Every existing `/me` and associate test was rewritten against the new semantics, plus new ones for the cases that used to pass vacuously: a colleague's cart refused, a list narrowed by `ViewMy…`, a list covering the unit with `ViewOthers…`, another unit's resource 404, a non-associate refused, an unknown business unit 404, per-action quote permissions, `/me` without a token, another customer's order 404 (id and in-store), and an anonymous session seeing only its own orders.

861 tests passing.

One unrelated test needed a fix: `custom-object.test.ts` had an unawaited `unsafeAdd` and only passed because the read raced ahead of the write. The extra middleware changed the timing and exposed it.