### PR TITLE
feat: persist expansionPaths, dependencies and additionalContext on extension create

### DIFF
--- a/.changeset/extension-create-fields.md
+++ b/.changeset/extension-create-fields.md
@@ -1,0 +1,20 @@
+---
+"@labdigital/commercetools-mock": minor
+---
+
+Persist `expansionPaths`, `dependencies` and `additionalContext` when creating
+an API Extension.
+
+The Extension repository only copied `key`, `timeoutInMs`, `destination` and
+`triggers` out of the draft, so the three fields added by the 2026-03-12 API
+release were silently dropped on create. `POST /{projectKey}/extensions` with
+`expansionPaths` returned an extension without them, which made it look like
+the field was rejected. The `setExpansionPaths`, `setDependencies` and
+`setAdditionalContext` update actions were already implemented, so only the
+create path was affected.
+
+`dependencies` are now resolved through the storage layer like every other
+resource identifier, so they can be given by `key` as well as by `id` (on both
+create and `setDependencies`, which previously assumed `id` was set) and an
+unknown dependency returns a `ReferencedResourceNotFound` error instead of a
+reference with `id: undefined`.

--- a/src/repositories/extension.test.ts
+++ b/src/repositories/extension.test.ts
@@ -3,6 +3,9 @@ import type {
 	ExtensionChangeDestinationAction,
 	ExtensionChangeTriggersAction,
 	ExtensionDraft,
+	ExtensionSetAdditionalContextAction,
+	ExtensionSetDependenciesAction,
+	ExtensionSetExpansionPathsAction,
 	ExtensionSetKeyAction,
 	ExtensionSetTimeoutInMsAction,
 } from "@commercetools/platform-sdk";
@@ -74,6 +77,119 @@ describe("Extension Repository", () => {
 		expect(result.key).toBe(draft.key);
 		expect(result.destination.type).toBe("AWSLambda");
 		expect(result.triggers).toEqual(draft.triggers);
+	});
+
+	test("create extension with expansion paths", async () => {
+		const draft: ExtensionDraft = {
+			key: "expansion-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [
+				{
+					resourceTypeId: "cart",
+					actions: ["Create"],
+				},
+			],
+			expansionPaths: ["lineItems[*].variant", "shippingInfo.shippingMethod"],
+		};
+
+		const ctx = { projectKey: "dummy" };
+		const result = await repository.create(ctx, draft);
+
+		expect(result.expansionPaths).toEqual([
+			"lineItems[*].variant",
+			"shippingInfo.shippingMethod",
+		]);
+	});
+
+	test("create extension without expansion paths", async () => {
+		const draft: ExtensionDraft = {
+			key: "no-expansion-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+		};
+
+		const ctx = { projectKey: "dummy" };
+		const result = await repository.create(ctx, draft);
+
+		expect(result.expansionPaths).toBeUndefined();
+		expect(result.dependencies).toBeUndefined();
+		expect(result.additionalContext).toBeUndefined();
+	});
+
+	test("create extension with additional context", async () => {
+		const draft: ExtensionDraft = {
+			key: "context-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+			additionalContext: { includeOldResource: true },
+		};
+
+		const ctx = { projectKey: "dummy" };
+		const result = await repository.create(ctx, draft);
+
+		expect(result.additionalContext).toEqual({ includeOldResource: true });
+	});
+
+	test("create extension with dependencies", async () => {
+		const ctx = { projectKey: "dummy" };
+		const dependency = await repository.create(ctx, {
+			key: "dependency-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/dependency",
+			},
+			triggers: [],
+		});
+
+		const byId = await repository.create(ctx, {
+			key: "dependent-by-id",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+			dependencies: [{ typeId: "extension", id: dependency.id }],
+		});
+		expect(byId.dependencies).toEqual([
+			{ typeId: "extension", id: dependency.id },
+		]);
+
+		const byKey = await repository.create(ctx, {
+			key: "dependent-by-key",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+			dependencies: [{ typeId: "extension", key: "dependency-extension" }],
+		});
+		expect(byKey.dependencies).toEqual([
+			{ typeId: "extension", id: dependency.id },
+		]);
+	});
+
+	test("create extension with unknown dependency", async () => {
+		const ctx = { projectKey: "dummy" };
+		await expect(
+			repository.create(ctx, {
+				key: "dependent-on-nothing",
+				destination: {
+					type: "HTTP",
+					url: "https://example.com/webhook",
+				},
+				triggers: [],
+				dependencies: [{ typeId: "extension", key: "does-not-exist" }],
+			}),
+		).rejects.toThrow(/was not found/);
 	});
 
 	test("postProcessResource masks HTTP authentication header", async () => {
@@ -268,6 +384,114 @@ describe("Extension Repository", () => {
 		);
 
 		expect(result.timeoutInMs).toBe(5000);
+		expect(result.version).toBe(extension.version + 1);
+	});
+
+	test("update extension - setExpansionPaths", async () => {
+		const ctx = { projectKey: "dummy" };
+		const extension = await repository.create(ctx, {
+			key: "expansion-update-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+			expansionPaths: ["lineItems[*].variant"],
+		});
+
+		const result = await repository.processUpdateActions(
+			ctx,
+			extension,
+			extension.version,
+			[
+				{
+					action: "setExpansionPaths",
+					expansionPaths: ["custom.type"],
+				} as ExtensionSetExpansionPathsAction,
+			],
+		);
+
+		expect(result.expansionPaths).toEqual(["custom.type"]);
+		expect(result.version).toBe(extension.version + 1);
+
+		// An empty array removes all expansion paths
+		const cleared = await repository.processUpdateActions(
+			ctx,
+			result,
+			result.version,
+			[
+				{
+					action: "setExpansionPaths",
+					expansionPaths: [],
+				} as ExtensionSetExpansionPathsAction,
+			],
+		);
+
+		expect(cleared.expansionPaths).toEqual([]);
+		expect(cleared.version).toBe(result.version + 1);
+	});
+
+	test("update extension - setDependencies", async () => {
+		const ctx = { projectKey: "dummy" };
+		const dependency = await repository.create(ctx, {
+			key: "dependency-for-update",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/dependency",
+			},
+			triggers: [],
+		});
+		const extension = await repository.create(ctx, {
+			key: "dependency-update-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+		});
+
+		const result = await repository.processUpdateActions(
+			ctx,
+			extension,
+			extension.version,
+			[
+				{
+					action: "setDependencies",
+					dependencies: [{ typeId: "extension", key: "dependency-for-update" }],
+				} as ExtensionSetDependenciesAction,
+			],
+		);
+
+		expect(result.dependencies).toEqual([
+			{ typeId: "extension", id: dependency.id },
+		]);
+		expect(result.version).toBe(extension.version + 1);
+	});
+
+	test("update extension - setAdditionalContext", async () => {
+		const ctx = { projectKey: "dummy" };
+		const extension = await repository.create(ctx, {
+			key: "context-update-extension",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [],
+		});
+
+		const result = await repository.processUpdateActions(
+			ctx,
+			extension,
+			extension.version,
+			[
+				{
+					action: "setAdditionalContext",
+					additionalContext: { includeOldResource: true },
+				} as ExtensionSetAdditionalContextAction,
+			],
+		);
+
+		expect(result.additionalContext).toEqual({ includeOldResource: true });
 		expect(result.version).toBe(extension.version + 1);
 	});
 

--- a/src/repositories/extension.ts
+++ b/src/repositories/extension.ts
@@ -4,6 +4,7 @@ import type {
 	ExtensionChangeTriggersAction,
 	ExtensionDraft,
 	ExtensionReference,
+	ExtensionResourceIdentifier,
 	ExtensionSetAdditionalContextAction,
 	ExtensionSetDependenciesAction,
 	ExtensionSetExpansionPathsAction,
@@ -15,6 +16,7 @@ import type { Config } from "#src/config.ts";
 import { ExtensionDraftSchema } from "#src/schemas/generated/extension.ts";
 import { getBaseResourceProperties } from "../helpers.ts";
 import { maskSecretValue } from "../lib/masking.ts";
+import type { AbstractStorage } from "../storage/abstract.ts";
 import type { Writable } from "../types.ts";
 import type { UpdateHandlerInterface } from "./abstract.ts";
 import {
@@ -22,6 +24,7 @@ import {
 	AbstractUpdateHandler,
 	type RepositoryContext,
 } from "./abstract.ts";
+import { getReferenceFromResourceIdentifier } from "./helpers.ts";
 
 export class ExtensionRepository extends AbstractResourceRepository<"extension"> {
 	constructor(config: Config) {
@@ -40,6 +43,20 @@ export class ExtensionRepository extends AbstractResourceRepository<"extension">
 			timeoutInMs: draft.timeoutInMs,
 			destination: draft.destination,
 			triggers: draft.triggers,
+			dependencies: draft.dependencies
+				? await resolveExtensionDependencies(
+						context,
+						this._storage,
+						draft.dependencies,
+					)
+				: undefined,
+			expansionPaths: draft.expansionPaths ?? undefined,
+			additionalContext: draft.additionalContext
+				? {
+						includeOldResource:
+							draft.additionalContext.includeOldResource ?? false,
+					}
+				: undefined,
 		};
 		return await this.saveNew(context, resource);
 	}
@@ -97,16 +114,15 @@ class ExtensionUpdateHandler
 		};
 	}
 
-	setDependencies(
+	async setDependencies(
 		context: RepositoryContext,
 		resource: Writable<Extension>,
 		action: ExtensionSetDependenciesAction,
-	): void {
-		resource.dependencies = action.dependencies.map(
-			(identifier): ExtensionReference => ({
-				typeId: "extension",
-				id: identifier.id!,
-			}),
+	): Promise<void> {
+		resource.dependencies = await resolveExtensionDependencies(
+			context,
+			this._storage,
+			action.dependencies,
 		);
 	}
 
@@ -134,3 +150,20 @@ class ExtensionUpdateHandler
 		resource.timeoutInMs = action.timeoutInMs;
 	}
 }
+
+// Dependencies are given as resource identifiers (by `id` or `key`) but stored
+// as references, so the referenced extensions are resolved here.
+const resolveExtensionDependencies = async (
+	context: RepositoryContext,
+	storage: AbstractStorage,
+	dependencies: ExtensionResourceIdentifier[],
+): Promise<ExtensionReference[]> =>
+	Promise.all(
+		dependencies.map((identifier) =>
+			getReferenceFromResourceIdentifier<ExtensionReference>(
+				identifier,
+				context.projectKey,
+				storage,
+			),
+		),
+	);

--- a/src/services/extension.test.ts
+++ b/src/services/extension.test.ts
@@ -50,6 +50,56 @@ describe("Extension", () => {
 		});
 	});
 
+	test("Create extension with expansion paths", async () => {
+		const draft = extensionDraft.build({
+			key: "cart-expansion",
+			destination: {
+				type: "HTTP",
+				url: "https://example.com/webhook",
+			},
+			triggers: [
+				{
+					resourceTypeId: "cart",
+					actions: ["Create"],
+				},
+			],
+			expansionPaths: ["lineItems[*].variant"],
+			additionalContext: { includeOldResource: true },
+		});
+
+		const response = await ctMock.app.inject({
+			method: "POST",
+			url: "/dummy/extensions",
+			payload: draft,
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().expansionPaths).toEqual(["lineItems[*].variant"]);
+		expect(response.json().additionalContext).toEqual({
+			includeOldResource: true,
+		});
+
+		const updated = await ctMock.app.inject({
+			method: "POST",
+			url: `/dummy/extensions/${response.json().id}`,
+			payload: {
+				version: response.json().version,
+				actions: [
+					{
+						action: "setExpansionPaths",
+						expansionPaths: ["custom.type", "shippingInfo.shippingMethod"],
+					},
+				],
+			},
+		});
+
+		expect(updated.statusCode).toBe(200);
+		expect(updated.json().expansionPaths).toEqual([
+			"custom.type",
+			"shippingInfo.shippingMethod",
+		]);
+	});
+
 	test("Get extension", async () => {
 		const extension = await extensionDraft.create({
 			key: "test-extension",


### PR DESCRIPTION
## Problem

`ExtensionRepository.create()` only copied `key`, `timeoutInMs`, `destination` and `triggers` out of the draft, so the three fields added by the [2026-03-12 API release](https://docs.commercetools.com/api/releases/2026-03-12-added-reference-expansion-in-api-extensions) were silently dropped:

- `expansionPaths`
- `dependencies`
- `additionalContext`

`POST /{projectKey}/extensions` with `expansionPaths` returned an extension without them, which looks from the client side like the field was rejected. The Zod draft schema already accepted all three, and the `setExpansionPaths` / `setDependencies` / `setAdditionalContext` update actions were already implemented — only the create path was affected.

Found while adding `expansion_paths` support to the Terraform provider, where the acceptance test could not pass against the mock.

## Changes

- `create()` persists `expansionPaths`, `dependencies` and `additionalContext`.
- `dependencies` are resolved through `getReferenceFromResourceIdentifier` instead of being mapped with `identifier.id!`. They can now be given by `key` as well as by `id`, and an unknown dependency returns `ReferencedResourceNotFound` rather than a reference with `id: undefined`. This fixes `setDependencies` too, which had the same assumption.
- 8 repository tests and 1 service-level HTTP round-trip test.
- Changeset (minor).

## Verification

`pnpm tsc`, `pnpm biome check` and `pnpm test` (893 tests / 86 files) pass.

End-to-end: ran this branch's server on `:8989` and pointed the Terraform provider's API extension acceptance tests at it — create with paths, plan-only no-diff, update paths, remove paths all pass. Against the released `3.0.0-beta.3` image the same test fails on the read-back.